### PR TITLE
[Feat] 로그아웃 기능 개발

### DIFF
--- a/src/main/java/com/jaeychoi/dailyus/auth/controller/AuthController.java
+++ b/src/main/java/com/jaeychoi/dailyus/auth/controller/AuthController.java
@@ -1,13 +1,18 @@
 package com.jaeychoi.dailyus.auth.controller;
 
+import com.jaeychoi.dailyus.auth.annotation.AuthRequired;
+import com.jaeychoi.dailyus.auth.annotation.AuthenticatedUser;
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.auth.dto.LogoutRequest;
 import com.jaeychoi.dailyus.auth.dto.RefreshTokenRequest;
 import com.jaeychoi.dailyus.auth.dto.SignInRequest;
 import com.jaeychoi.dailyus.auth.dto.SignUpRequest;
 import com.jaeychoi.dailyus.auth.dto.SignUpResponse;
 import com.jaeychoi.dailyus.auth.dto.TokenResponse;
+import com.jaeychoi.dailyus.auth.service.LogoutService;
+import com.jaeychoi.dailyus.auth.service.RefreshTokenService;
 import com.jaeychoi.dailyus.auth.service.SignInService;
 import com.jaeychoi.dailyus.auth.service.SignUpService;
-import com.jaeychoi.dailyus.auth.service.RefreshTokenService;
 import com.jaeychoi.dailyus.common.web.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,7 @@ public class AuthController {
   private final SignUpService signUpService;
   private final SignInService signInService;
   private final RefreshTokenService refreshTokenService;
+  private final LogoutService logoutService;
 
   @PostMapping("/signup")
   @ResponseStatus(HttpStatus.CREATED)
@@ -44,5 +50,15 @@ public class AuthController {
   public ApiResponse<TokenResponse> refresh(@Valid @RequestBody RefreshTokenRequest request) {
     TokenResponse response = refreshTokenService.refresh(request);
     return ApiResponse.success(response);
+  }
+
+  @PostMapping("/logout")
+  @AuthRequired
+  public ApiResponse<Void> logout(
+      @AuthenticatedUser CurrentUser currentUser,
+      @Valid @RequestBody LogoutRequest request
+  ) {
+    logoutService.logout(currentUser, request);
+    return ApiResponse.success(null);
   }
 }

--- a/src/main/java/com/jaeychoi/dailyus/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/jaeychoi/dailyus/auth/dto/LogoutRequest.java
@@ -1,0 +1,6 @@
+package com.jaeychoi.dailyus.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(@NotBlank String refreshToken) {
+}

--- a/src/main/java/com/jaeychoi/dailyus/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/jaeychoi/dailyus/auth/repository/RefreshTokenRepository.java
@@ -35,6 +35,28 @@ public class RefreshTokenRepository {
       """,
       Long.class
   );
+  private static final DefaultRedisScript<Long> REVOKE_SCRIPT = new DefaultRedisScript<>(
+      """
+      local activeKey = KEYS[1]
+      local blacklistKey = KEYS[2]
+      local currentTokenId = ARGV[1]
+      local blacklistTtlMillis = tonumber(ARGV[2])
+      local activeTokenId = redis.call('GET', activeKey)
+
+      if not activeTokenId or activeTokenId ~= currentTokenId then
+        return 0
+      end
+
+      redis.call('DEL', activeKey)
+
+      if blacklistTtlMillis > 0 then
+        redis.call('SET', blacklistKey, '1', 'PX', blacklistTtlMillis)
+      end
+
+      return 1
+      """,
+      Long.class
+  );
 
   private final StringRedisTemplate redisTemplate;
 
@@ -65,6 +87,16 @@ public class RefreshTokenRepository {
   public boolean isBlacklisted(String tokenId) {
     Boolean hasKey = redisTemplate.hasKey(blacklistKey(tokenId));
     return Boolean.TRUE.equals(hasKey);
+  }
+
+  public boolean revoke(Long userId, RefreshTokenDetails refreshTokenDetails) {
+    Long updated = redisTemplate.execute(
+        REVOKE_SCRIPT,
+        List.of(activeKey(userId), blacklistKey(refreshTokenDetails.tokenId())),
+        refreshTokenDetails.tokenId(),
+        String.valueOf(ttlUntil(refreshTokenDetails.expiresAt()).toMillis())
+    );
+    return updated != null && updated == 1L;
   }
 
   private String activeKey(Long userId) {

--- a/src/main/java/com/jaeychoi/dailyus/auth/service/LogoutService.java
+++ b/src/main/java/com/jaeychoi/dailyus/auth/service/LogoutService.java
@@ -1,0 +1,32 @@
+package com.jaeychoi.dailyus.auth.service;
+
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.auth.dto.LogoutRequest;
+import com.jaeychoi.dailyus.auth.repository.RefreshTokenRepository;
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.common.jwt.JwtTokenProvider;
+import com.jaeychoi.dailyus.common.jwt.RefreshTokenDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  public void logout(CurrentUser currentUser, LogoutRequest request) {
+    RefreshTokenDetails refreshTokenDetails =
+        jwtTokenProvider.parseRefreshTokenDetails(request.refreshToken());
+
+    if (!currentUser.userId().equals(refreshTokenDetails.user().userId())) {
+      throw new BaseException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    if (!refreshTokenRepository.revoke(currentUser.userId(), refreshTokenDetails)) {
+      throw new BaseException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/auth/controller/AuthControllerTest.java
@@ -11,12 +11,17 @@ import com.jaeychoi.dailyus.auth.dto.SignInRequest;
 import com.jaeychoi.dailyus.auth.dto.SignUpRequest;
 import com.jaeychoi.dailyus.auth.dto.SignUpResponse;
 import com.jaeychoi.dailyus.auth.dto.TokenResponse;
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.auth.dto.LogoutRequest;
+import com.jaeychoi.dailyus.auth.service.LogoutService;
 import com.jaeychoi.dailyus.auth.service.RefreshTokenService;
 import com.jaeychoi.dailyus.auth.service.SignInService;
 import com.jaeychoi.dailyus.auth.service.SignUpService;
 import com.jaeychoi.dailyus.common.exception.BaseException;
 import com.jaeychoi.dailyus.common.exception.ErrorCode;
 import com.jaeychoi.dailyus.common.exception.GlobalExceptionHandler;
+import com.jaeychoi.dailyus.common.web.AuthRequestAttributes;
+import com.jaeychoi.dailyus.common.web.AuthenticatedUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +46,9 @@ class AuthControllerTest {
   @Mock
   private RefreshTokenService refreshTokenService;
 
+  @Mock
+  private LogoutService logoutService;
+
   private MockMvc mockMvc;
 
   private ObjectMapper objectMapper;
@@ -52,8 +60,9 @@ class AuthControllerTest {
 
     objectMapper = new ObjectMapper();
     mockMvc = MockMvcBuilders.standaloneSetup(
-            new AuthController(signUpService, signInService, refreshTokenService))
+            new AuthController(signUpService, signInService, refreshTokenService, logoutService))
         .setControllerAdvice(new GlobalExceptionHandler())
+        .setCustomArgumentResolvers(new AuthenticatedUserArgumentResolver())
         .setValidator(validator)
         .setMessageConverters(new JacksonJsonHttpMessageConverter())
         .build();
@@ -160,5 +169,34 @@ class AuthControllerTest {
         .andExpect(jsonPath("$.code").value("OK"))
         .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
         .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"));
+  }
+
+  @Test
+  void logoutReturnsOk() throws Exception {
+    LogoutRequest request = new LogoutRequest("refresh-token");
+
+    mockMvc.perform(post("/api/v1/auth/logout")
+            .requestAttr(
+                AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "tester@example.com", "tester"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.message").doesNotExist())
+        .andExpect(jsonPath("$.data").doesNotExist());
+  }
+
+  @Test
+  void logoutReturnsUnauthorizedWhenCurrentUserMissing() throws Exception {
+    LogoutRequest request = new LogoutRequest("refresh-token");
+
+    mockMvc.perform(post("/api/v1/auth/logout")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()))
+        .andExpect(jsonPath("$.data").doesNotExist());
   }
 }

--- a/src/test/java/com/jaeychoi/dailyus/auth/service/LogoutServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/auth/service/LogoutServiceTest.java
@@ -1,0 +1,90 @@
+package com.jaeychoi.dailyus.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.auth.dto.LogoutRequest;
+import com.jaeychoi.dailyus.auth.repository.RefreshTokenRepository;
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.common.jwt.JwtTokenProvider;
+import com.jaeychoi.dailyus.common.jwt.RefreshTokenDetails;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private RefreshTokenRepository refreshTokenRepository;
+
+  @InjectMocks
+  private LogoutService logoutService;
+
+  @Test
+  void logoutRevokesRefreshTokenWhenUserMatches() {
+    CurrentUser currentUser = new CurrentUser(1L, "tester@example.com", "tester");
+    LogoutRequest request = new LogoutRequest("refresh-token");
+    RefreshTokenDetails refreshTokenDetails = new RefreshTokenDetails(
+        currentUser,
+        "token-id",
+        Instant.parse("2026-04-10T00:00:00Z")
+    );
+
+    when(jwtTokenProvider.parseRefreshTokenDetails(request.refreshToken()))
+        .thenReturn(refreshTokenDetails);
+    when(refreshTokenRepository.revoke(1L, refreshTokenDetails)).thenReturn(true);
+
+    logoutService.logout(currentUser, request);
+
+    verify(refreshTokenRepository).revoke(1L, refreshTokenDetails);
+  }
+
+  @Test
+  void logoutThrowsWhenRefreshTokenBelongsToAnotherUser() {
+    CurrentUser currentUser = new CurrentUser(1L, "tester@example.com", "tester");
+    LogoutRequest request = new LogoutRequest("refresh-token");
+    RefreshTokenDetails refreshTokenDetails = new RefreshTokenDetails(
+        new CurrentUser(2L, "other@example.com", "other"),
+        "token-id",
+        Instant.parse("2026-04-10T00:00:00Z")
+    );
+
+    when(jwtTokenProvider.parseRefreshTokenDetails(request.refreshToken()))
+        .thenReturn(refreshTokenDetails);
+
+    assertThatThrownBy(() -> logoutService.logout(currentUser, request))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+  }
+
+  @Test
+  void logoutThrowsWhenStoredSessionDoesNotMatch() {
+    CurrentUser currentUser = new CurrentUser(1L, "tester@example.com", "tester");
+    LogoutRequest request = new LogoutRequest("refresh-token");
+    RefreshTokenDetails refreshTokenDetails = new RefreshTokenDetails(
+        currentUser,
+        "token-id",
+        Instant.parse("2026-04-10T00:00:00Z")
+    );
+
+    when(jwtTokenProvider.parseRefreshTokenDetails(request.refreshToken()))
+        .thenReturn(refreshTokenDetails);
+    when(refreshTokenRepository.revoke(1L, refreshTokenDetails)).thenReturn(false);
+
+    assertThatThrownBy(() -> logoutService.logout(currentUser, request))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+  }
+}


### PR DESCRIPTION
  ## ✨ 작업 내용
  - `POST /api/v1/auth/logout` 엔드포인트 추가
  - Access Token 인증 사용자와 Refresh Token 소유자가 일치하는지 검증 로직 구현
  - Refresh Token 폐기 처리 및 유효하지 않은 토큰 예외 응답 추가
  - 로그아웃 서비스 및 컨트롤러 테스트 작성

  ## 관련 이슈
  - closes #14 

  ## 스크린샷 / 참고 자료
  <!-- 필요한 경우 첨부 -->