### PR TITLE
[Feat] 게시물 생성 기능 구현

### DIFF
--- a/src/main/java/com/jaeychoi/dailyus/common/exception/ErrorCode.java
+++ b/src/main/java/com/jaeychoi/dailyus/common/exception/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_003", "User not found."),
   SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "USR_004", "You cannot follow yourself."),
   FOLLOW_ALREADY_EXISTS(HttpStatus.CONFLICT, "USR_005", "Follow relationship already exists."),
-  FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_006", "Follow relationship not found.");
+  FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_006", "Follow relationship not found."),
+  POST_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "PST_001", "At least one image is required."),
+  POST_HASHTAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PST_003",
+      "No more than 10 hashtags are allowed.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/jaeychoi/dailyus/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/jaeychoi/dailyus/hashtag/domain/Hashtag.java
@@ -1,0 +1,20 @@
+package com.jaeychoi.dailyus.hashtag.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hashtag {
+
+  private Long hashtagId;
+  private String name;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/jaeychoi/dailyus/hashtag/mapper/HashtagMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/hashtag/mapper/HashtagMapper.java
@@ -1,0 +1,16 @@
+package com.jaeychoi.dailyus.hashtag.mapper;
+
+import com.jaeychoi.dailyus.hashtag.domain.Hashtag;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface HashtagMapper {
+
+  List<Hashtag> findByNames(@Param("names") List<String> names);
+
+  void insert(Hashtag hashtag);
+
+  void insertPostHashtags(@Param("postId") Long postId, @Param("hashtagIds") List<Long> hashtagIds);
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
@@ -1,0 +1,33 @@
+package com.jaeychoi.dailyus.post.controller;
+
+import com.jaeychoi.dailyus.auth.annotation.AuthRequired;
+import com.jaeychoi.dailyus.auth.annotation.AuthenticatedUser;
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.common.web.ApiResponse;
+import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
+import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.post.service.PostCreateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+  private final PostCreateService postCreateService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  @AuthRequired
+  public ApiResponse<PostCreateResponse> createPost(@AuthenticatedUser CurrentUser user,
+      @Valid @RequestBody PostCreateRequest request) {
+    return ApiResponse.success(postCreateService.createPost(user.userId(), request));
+  }
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/domain/Post.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/domain/Post.java
@@ -1,0 +1,25 @@
+package com.jaeychoi.dailyus.post.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post {
+
+  private Long postId;
+  private String content;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private LocalDateTime deletedAt;
+  @Builder.Default
+  private Long likeCount = 0L;
+  private Long userId;
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostCreateRequest.java
@@ -1,0 +1,15 @@
+package com.jaeychoi.dailyus.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record PostCreateRequest(
+    @NotEmpty
+    @Size(max = 10)
+    List<@NotBlank @Size(max = 500) String> imageUrls,
+    @Size(max = 2200) String content
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostCreateResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostCreateResponse.java
@@ -1,0 +1,14 @@
+package com.jaeychoi.dailyus.post.dto;
+
+import java.util.List;
+
+public record PostCreateResponse(
+    Long postId,
+    Long userId,
+    String content,
+    List<String> imageUrls,
+    List<String> hashtags,
+    Long likeCount
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
@@ -1,0 +1,14 @@
+package com.jaeychoi.dailyus.post.mapper;
+
+import com.jaeychoi.dailyus.post.domain.Post;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PostMapper {
+
+  void insert(Post post);
+
+  void insertImages(Long postId, List<String> imageUrls);
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/service/PostCreateService.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/service/PostCreateService.java
@@ -1,0 +1,109 @@
+package com.jaeychoi.dailyus.post.service;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.hashtag.domain.Hashtag;
+import com.jaeychoi.dailyus.hashtag.mapper.HashtagMapper;
+import com.jaeychoi.dailyus.post.domain.Post;
+import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
+import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.post.mapper.PostMapper;
+import com.jaeychoi.dailyus.utils.HashtagExtractor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostCreateService {
+
+  private static final int MAX_HASHTAG_COUNT = 10;
+
+  private final PostMapper postMapper;
+  private final HashtagMapper hashtagMapper;
+
+  @Transactional
+  public PostCreateResponse createPost(Long userId, PostCreateRequest request) {
+    if (request.imageUrls() == null || request.imageUrls().isEmpty()) {
+      throw new BaseException(ErrorCode.POST_IMAGE_REQUIRED);
+    }
+
+    List<String> hashtags = HashtagExtractor.extract(request.content());
+    validateHashtagCount(hashtags);
+    Post post = Post.builder()
+        .userId(userId)
+        .content(request.content())
+        .build();
+
+    postMapper.insert(post);
+    postMapper.insertImages(post.getPostId(), request.imageUrls());
+    saveHashtags(post.getPostId(), hashtags);
+
+    return new PostCreateResponse(
+        post.getPostId(),
+        userId,
+        request.content(),
+        request.imageUrls(),
+        hashtags,
+        post.getLikeCount()
+    );
+  }
+
+  private void validateHashtagCount(List<String> hashtags) {
+    if (hashtags.size() > MAX_HASHTAG_COUNT) {
+      throw new BaseException(ErrorCode.POST_HASHTAG_LIMIT_EXCEEDED);
+    }
+  }
+
+  private void saveHashtags(Long postId, List<String> hashtags) {
+    if (hashtags.isEmpty()) {
+      return;
+    }
+    Map<String, Hashtag> existingHashtags = findExistingHashtags(hashtags);
+    List<Long> hashtagIds = resolveHashtagIds(hashtags, existingHashtags);
+
+    if (!hashtagIds.isEmpty()) {
+      hashtagMapper.insertPostHashtags(postId, hashtagIds);
+    }
+  }
+
+  private Map<String, Hashtag> findExistingHashtags(List<String> hashtags) {
+    return hashtagMapper.findByNames(hashtags).stream()
+        .collect(Collectors.toMap(
+            hashtag -> HashtagExtractor.normalize(hashtag.getName()),
+            Function.identity()
+        ));
+  }
+
+  private List<Long> resolveHashtagIds(List<String> hashtags,
+      Map<String, Hashtag> existingHashtags) {
+    List<Long> hashtagIds = new ArrayList<>();
+
+    for (String hashtagName : hashtags) {
+      Hashtag hashtag = findOrCreateHashtag(hashtagName, existingHashtags);
+      hashtagIds.add(hashtag.getHashtagId());
+    }
+
+    return hashtagIds;
+  }
+
+  private Hashtag findOrCreateHashtag(String hashtagName, Map<String, Hashtag> existingHashtags) {
+    String normalizedName = HashtagExtractor.normalize(hashtagName);
+    Hashtag hashtag = existingHashtags.get(normalizedName);
+    if (hashtag != null) {
+      return hashtag;
+    }
+
+    Hashtag newHashtag = Hashtag.builder()
+        .name(hashtagName)
+        .build();
+    hashtagMapper.insert(newHashtag);
+    existingHashtags.put(normalizedName, newHashtag);
+    return newHashtag;
+  }
+}

--- a/src/main/java/com/jaeychoi/dailyus/utils/HashtagExtractor.java
+++ b/src/main/java/com/jaeychoi/dailyus/utils/HashtagExtractor.java
@@ -1,0 +1,42 @@
+package com.jaeychoi.dailyus.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class HashtagExtractor {
+
+  private static final Pattern HASHTAG_PATTERN = Pattern.compile(
+      "(?<!\\S)#([\\p{L}\\p{N}_]{1,30})");
+
+  private HashtagExtractor() {
+  }
+
+  public static String normalize(String hashtag) {
+    return hashtag.toLowerCase(Locale.ROOT);
+  }
+
+  public static List<String> extract(String content) {
+    if (content == null || content.isBlank()) {
+      return List.of();
+    }
+
+    Matcher matcher = HASHTAG_PATTERN.matcher(content);
+    List<String> hashtags = new ArrayList<>();
+    Set<String> normalizedNames = new LinkedHashSet<>();
+
+    while (matcher.find()) {
+      String hashtag = matcher.group(1);
+      String normalized = normalize(hashtag);
+      if (normalizedNames.add(normalized)) {
+        hashtags.add(normalized);
+      }
+    }
+
+    return hashtags;
+  }
+}

--- a/src/main/resources/mapper/hashtag/HashtagMapper.xml
+++ b/src/main/resources/mapper/hashtag/HashtagMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jaeychoi.dailyus.hashtag.mapper.HashtagMapper">
+
+    <select id="findByNames" resultType="com.jaeychoi.dailyus.hashtag.domain.Hashtag">
+        SELECT hashtag_id, name, created_at
+        FROM hashtag
+        WHERE name IN
+        <foreach collection="names" item="name" open="(" separator="," close=")">
+            #{name}
+        </foreach>
+    </select>
+
+    <insert id="insert"
+            parameterType="com.jaeychoi.dailyus.hashtag.domain.Hashtag"
+            useGeneratedKeys="true"
+            keyProperty="hashtagId">
+        INSERT INTO hashtag (name)
+        VALUES (#{name})
+    </insert>
+
+    <insert id="insertPostHashtags">
+        INSERT INTO hashtag_posts (
+            hashtag_id,
+            post_id
+        ) VALUES
+        <foreach collection="hashtagIds" item="hashtagId" separator=",">
+            (
+                #{hashtagId},
+                #{postId}
+            )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/post/PostMapper.xml
+++ b/src/main/resources/mapper/post/PostMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jaeychoi.dailyus.post.mapper.PostMapper">
+
+    <insert id="insert"
+            parameterType="com.jaeychoi.dailyus.post.domain.Post"
+            useGeneratedKeys="true"
+            keyProperty="postId">
+        INSERT INTO posts (
+            content,
+            user_id
+        ) VALUES (
+            #{content},
+            #{userId}
+        )
+    </insert>
+
+    <insert id="insertImages">
+        INSERT INTO post_images (
+            image_url,
+            post_id
+        ) VALUES
+        <foreach collection="imageUrls" item="imageUrl" separator=",">
+            (
+                #{imageUrl},
+                #{postId}
+            )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/test/java/com/jaeychoi/dailyus/hashtag/mapper/HashtagMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/hashtag/mapper/HashtagMapperTest.java
@@ -1,0 +1,168 @@
+package com.jaeychoi.dailyus.hashtag.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jaeychoi.dailyus.hashtag.domain.Hashtag;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+@MybatisTest
+class HashtagMapperTest {
+
+  @Autowired
+  private HashtagMapper hashtagMapper;
+
+  @Autowired
+  private DataSource dataSource;
+
+  @Test
+  void findByNamesReturnsMatchingHashtags() throws Exception {
+    // given
+    insertHashtag("morning-find");
+    insertHashtag("routine-find");
+    insertHashtag("fitness-find");
+
+    // when
+    List<Hashtag> hashtags = hashtagMapper.findByNames(List.of("morning-find", "routine-find"));
+
+    // then
+    assertThat(hashtags)
+        .extracting(Hashtag::getName)
+        .containsExactlyInAnyOrder("morning-find", "routine-find");
+  }
+
+  @Test
+  void insertPersistsHashtagAndSetsGeneratedKey() throws Exception {
+    // given
+    Hashtag hashtag = Hashtag.builder()
+        .name("daily-insert")
+        .build();
+
+    // when
+    hashtagMapper.insert(hashtag);
+
+    // then
+    assertThat(hashtag.getHashtagId()).isNotNull();
+    assertThat(countHashtagsByName("daily-insert")).isEqualTo(1);
+  }
+
+  @Test
+  void insertPostHashtagsPersistsRelations() throws Exception {
+    // given
+    Long userId = insertUser("writer@example.com", "writer");
+    Long postId = insertPost(userId, "post content");
+    Long morningId = insertHashtag("morning-link");
+    Long routineId = insertHashtag("routine-link");
+
+    // when
+    hashtagMapper.insertPostHashtags(postId, List.of(morningId, routineId));
+
+    // then
+    assertThat(countHashtagPost(postId, morningId)).isEqualTo(1);
+    assertThat(countHashtagPost(postId, routineId)).isEqualTo(1);
+  }
+
+  private Long insertUser(String email, String nickname) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO users (
+                    email,
+                    password,
+                    nickname,
+                    follower_count,
+                    followee_count,
+                    profile_image,
+                    deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+            new String[]{"user_id"}
+        )) {
+      statement.setString(1, email);
+      statement.setString(2, "encoded-password");
+      statement.setString(3, nickname);
+      statement.setLong(4, 0L);
+      statement.setLong(5, 0L);
+      statement.setString(6, null);
+      statement.setTimestamp(7, null);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private Long insertPost(Long userId, String content) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO posts (
+                    content,
+                    user_id
+                ) VALUES (?, ?)
+                """,
+            new String[]{"post_id"}
+        )) {
+      statement.setString(1, content);
+      statement.setLong(2, userId);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private Long insertHashtag(String name) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            "INSERT INTO hashtag (name) VALUES (?)",
+            new String[]{"hashtag_id"}
+        )) {
+      statement.setString(1, name);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private int countHashtagsByName(String name) throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM hashtag WHERE name = ?"
+    )) {
+      statement.setString(1, name);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+  }
+
+  private int countHashtagPost(Long postId, Long hashtagId) throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM hashtag_posts WHERE post_id = ? AND hashtag_id = ?"
+    )) {
+      statement.setLong(1, postId);
+      statement.setLong(2, hashtagId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
@@ -1,0 +1,94 @@
+package com.jaeychoi.dailyus.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.common.exception.GlobalExceptionHandler;
+import com.jaeychoi.dailyus.common.web.AuthRequestAttributes;
+import com.jaeychoi.dailyus.common.web.AuthenticatedUserArgumentResolver;
+import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
+import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.post.service.PostCreateService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class PostControllerTest {
+
+  @Mock
+  private PostCreateService postCreateService;
+
+  private MockMvc mockMvc;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+    validator.afterPropertiesSet();
+
+    mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postCreateService))
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .setCustomArgumentResolvers(new AuthenticatedUserArgumentResolver())
+        .setValidator(validator)
+        .setMessageConverters(new JacksonJsonHttpMessageConverter())
+        .build();
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  void createPostReturnsCreatedResponse() throws Exception {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png"),
+        "미라클 모닝 #Morning"
+    );
+    PostCreateResponse response = new PostCreateResponse(
+        10L,
+        1L,
+        request.content(),
+        request.imageUrls(),
+        List.of("morning"),
+        0L
+    );
+    when(postCreateService.createPost(anyLong(), any(PostCreateRequest.class))).thenReturn(
+        response);
+
+    mockMvc.perform(post("/api/v1/posts")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.data.postId").value(10L))
+        .andExpect(jsonPath("$.data.userId").value(1L))
+        .andExpect(jsonPath("$.data.hashtags[0]").value("morning"));
+  }
+
+  @Test
+  void createPostReturnsBadRequestWhenImagesAreEmpty() throws Exception {
+    PostCreateRequest request = new PostCreateRequest(List.of(), "매일 매일");
+
+    mockMvc.perform(post("/api/v1/posts")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
@@ -1,0 +1,157 @@
+package com.jaeychoi.dailyus.post.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jaeychoi.dailyus.post.domain.Post;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+@MybatisTest
+class PostMapperTest {
+
+  @Autowired
+  private PostMapper postMapper;
+
+  @Autowired
+  private DataSource dataSource;
+
+  @Test
+  void insertPersistsPostAndSetsGeneratedKey() throws Exception {
+    // given
+    Long userId = insertUser("author@example.com", "author");
+    Post post = Post.builder()
+        .userId(userId)
+        .content("today's routine")
+        .build();
+
+    // when
+    postMapper.insert(post);
+
+    // then
+    assertThat(post.getPostId()).isNotNull();
+    assertThat(countPosts(post.getPostId())).isEqualTo(1);
+  }
+
+  @Test
+  void insertImagesPersistsAllPostImages() throws Exception {
+    // given
+    Long userId = insertUser("images@example.com", "images");
+    Long postId = insertPost(userId, "post with images");
+    List<String> imageUrls = List.of(
+        "https://cdn.example.com/1.png",
+        "https://cdn.example.com/2.png"
+    );
+
+    // when
+    postMapper.insertImages(postId, imageUrls);
+
+    // then
+    assertThat(countPostImages(postId)).isEqualTo(2);
+    assertThat(loadPostImageUrls(postId))
+        .containsExactlyInAnyOrderElementsOf(imageUrls);
+  }
+
+  private Long insertUser(String email, String nickname) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO users (
+                    email,
+                    password,
+                    nickname,
+                    follower_count,
+                    followee_count,
+                    profile_image,
+                    deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+            new String[]{"user_id"}
+        )) {
+      statement.setString(1, email);
+      statement.setString(2, "encoded-password");
+      statement.setString(3, nickname);
+      statement.setLong(4, 0L);
+      statement.setLong(5, 0L);
+      statement.setString(6, null);
+      statement.setTimestamp(7, null);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private Long insertPost(Long userId, String content) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO posts (
+                    content,
+                    user_id
+                ) VALUES (?, ?)
+                """,
+            new String[]{"post_id"}
+        )) {
+      statement.setString(1, content);
+      statement.setLong(2, userId);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private int countPosts(Long postId) throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM posts WHERE post_id = ?"
+    )) {
+      statement.setLong(1, postId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+  }
+
+  private int countPostImages(Long postId) throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM post_images WHERE post_id = ?"
+    )) {
+      statement.setLong(1, postId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+  }
+
+  private List<String> loadPostImageUrls(Long postId) throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        "SELECT image_url FROM post_images WHERE post_id = ?"
+    )) {
+      statement.setLong(1, postId);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        List<String> imageUrls = new ArrayList<>();
+        while (resultSet.next()) {
+          imageUrls.add(resultSet.getString(1));
+        }
+        return imageUrls;
+      }
+    }
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/post/service/PostCreateServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/service/PostCreateServiceTest.java
@@ -1,0 +1,180 @@
+package com.jaeychoi.dailyus.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.hashtag.domain.Hashtag;
+import com.jaeychoi.dailyus.post.domain.Post;
+import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
+import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.hashtag.mapper.HashtagMapper;
+import com.jaeychoi.dailyus.post.mapper.PostMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostCreateServiceTest {
+
+  @Mock
+  private PostMapper postMapper;
+
+  @Mock
+  private HashtagMapper hashtagMapper;
+
+  @InjectMocks
+  private PostCreateService postCreateService;
+
+  @Test
+  void createPostPersistsPostImagesAndHashtags() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png", "https://cdn.example.com/2.png"),
+        "자바 매일 #Morning #Routine"
+    );
+    doAnswer(invocation -> {
+      Post post = invocation.getArgument(0);
+      post.setPostId(10L);
+      return null;
+    }).when(postMapper).insert(any(Post.class));
+    when(hashtagMapper.findByNames(List.of("morning", "routine")))
+        .thenReturn(List.of(Hashtag.builder().hashtagId(30L).name("routine").build()));
+    doAnswer(invocation -> {
+      Hashtag hashtag = invocation.getArgument(0);
+      hashtag.setHashtagId(20L);
+      return null;
+    }).when(hashtagMapper).insert(any(Hashtag.class));
+
+    PostCreateResponse response = postCreateService.createPost(1L, request);
+
+    ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
+    verify(postMapper).insert(postCaptor.capture());
+    verify(postMapper).insertImages(10L, request.imageUrls());
+    verify(hashtagMapper).insertPostHashtags(10L, List.of(20L, 30L));
+
+    assertThat(postCaptor.getValue().getUserId()).isEqualTo(1L);
+    assertThat(postCaptor.getValue().getContent()).isEqualTo(request.content());
+    assertThat(response.postId()).isEqualTo(10L);
+    assertThat(response.imageUrls()).containsExactlyElementsOf(request.imageUrls());
+    assertThat(response.hashtags()).containsExactly("morning", "routine");
+  }
+
+  @Test
+  void createPostThrowsWhenImagesAreMissing() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of(),
+        "text"
+    );
+
+    assertThatThrownBy(() -> postCreateService.createPost(99L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.POST_IMAGE_REQUIRED);
+
+    verify(postMapper, never()).insert(any(Post.class));
+  }
+
+  @Test
+  void createPostNormalizesNewHashtagsBeforeInsert() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png"),
+        "#Morning #ROUTINE"
+    );
+    doAnswer(invocation -> {
+      Post post = invocation.getArgument(0);
+      post.setPostId(10L);
+      return null;
+    }).when(postMapper).insert(any(Post.class));
+    when(hashtagMapper.findByNames(List.of("morning", "routine"))).thenReturn(List.of());
+    doAnswer(invocation -> {
+      Hashtag hashtag = invocation.getArgument(0);
+      if ("morning".equals(hashtag.getName())) {
+        hashtag.setHashtagId(21L);
+      } else if ("routine".equals(hashtag.getName())) {
+        hashtag.setHashtagId(22L);
+      }
+      return null;
+    }).when(hashtagMapper).insert(any(Hashtag.class));
+
+    postCreateService.createPost(1L, request);
+
+    ArgumentCaptor<Hashtag> hashtagCaptor = ArgumentCaptor.forClass(Hashtag.class);
+    verify(hashtagMapper, times(2)).insert(hashtagCaptor.capture());
+    assertThat(hashtagCaptor.getAllValues())
+        .extracting(Hashtag::getName)
+        .containsExactly("morning", "routine");
+    verify(hashtagMapper).insertPostHashtags(10L, List.of(21L, 22L));
+  }
+
+  @Test
+  void createPostDeduplicatesHashtagsIgnoringCase() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png"),
+        "#Daily #daily #DAILY #Routine"
+    );
+    doAnswer(invocation -> {
+      Post post = invocation.getArgument(0);
+      post.setPostId(10L);
+      return null;
+    }).when(postMapper).insert(any(Post.class));
+    when(hashtagMapper.findByNames(List.of("daily", "routine")))
+        .thenReturn(List.of(
+            Hashtag.builder().hashtagId(11L).name("daily").build(),
+            Hashtag.builder().hashtagId(12L).name("routine").build()
+        ));
+
+    PostCreateResponse response = postCreateService.createPost(1L, request);
+
+    verify(postMapper).insert(any(Post.class));
+    verify(postMapper).insertImages(10L, request.imageUrls());
+    verify(hashtagMapper).insertPostHashtags(10L, List.of(11L, 12L));
+    assertThat(response.hashtags()).containsExactly("daily", "routine");
+  }
+
+  @Test
+  void createPostSkipsHashtagPersistenceWhenContentHasNoHashtags() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png"),
+        "plain text only"
+    );
+    doAnswer(invocation -> {
+      Post post = invocation.getArgument(0);
+      post.setPostId(10L);
+      return null;
+    }).when(postMapper).insert(any(Post.class));
+
+    PostCreateResponse response = postCreateService.createPost(1L, request);
+
+    verify(postMapper).insert(any(Post.class));
+    verify(postMapper).insertImages(10L, request.imageUrls());
+    verifyNoInteractions(hashtagMapper);
+    assertThat(response.hashtags()).isEmpty();
+  }
+
+  @Test
+  void createPostThrowsWhenHashtagLimitIsExceeded() {
+    PostCreateRequest request = new PostCreateRequest(
+        List.of("https://cdn.example.com/1.png"),
+        "#one #two #three #four #five #six #seven #eight #nine #ten #eleven"
+    );
+
+    assertThatThrownBy(() -> postCreateService.createPost(1L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.POST_HASHTAG_LIMIT_EXCEEDED);
+
+    verify(postMapper, never()).insert(any(Post.class));
+  }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -13,6 +13,48 @@ CREATE TABLE users (
     CONSTRAINT uk_users_email UNIQUE (email),
     CONSTRAINT uk_users_nickname UNIQUE (nickname)
 );
+CREATE TABLE posts (
+    post_id BIGINT NOT NULL AUTO_INCREMENT,
+    content TEXT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL,
+    like_count BIGINT NOT NULL DEFAULT 0,
+    user_id BIGINT NOT NULL,
+    PRIMARY KEY (post_id),
+    CONSTRAINT fk_posts_user_id
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE TABLE post_images (
+    post_image_id BIGINT NOT NULL AUTO_INCREMENT,
+    image_url VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL,
+    post_id BIGINT NOT NULL,
+    PRIMARY KEY (post_image_id),
+    CONSTRAINT fk_post_images_post_id
+        FOREIGN KEY (post_id) REFERENCES posts (post_id)
+);
+
+CREATE TABLE hashtag (
+    hashtag_id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (hashtag_id),
+    CONSTRAINT uk_hashtag_name UNIQUE (name)
+);
+
+CREATE TABLE hashtag_posts (
+    hashtag_id BIGINT NOT NULL,
+    post_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (hashtag_id, post_id),
+    CONSTRAINT fk_hashtag_posts_hashtag_id
+        FOREIGN KEY (hashtag_id) REFERENCES hashtag (hashtag_id),
+    CONSTRAINT fk_hashtag_posts_post_id
+        FOREIGN KEY (post_id) REFERENCES posts (post_id)
+);
 
 CREATE TABLE user_follow (
     follower BIGINT NOT NULL,


### PR DESCRIPTION
  ## ✨ 작업 내용
  - `POST /api/v1/posts` 게시물 생성 엔드포인트 추가
  -  해시태그를 추출 기능 구현
  - 게시물 이미지 필수 검증 및 해시태그 개수 제한 검증 추가
  - 게시물 생성 테스트 작성

  ## 관련 이슈
  - closes #23 

  ## 스크린샷 / 참고 자료
  <!-- 필요한 경우 첨부 -->