### PR TITLE
[Feat] 팔로우/언팔로우 기능 개발

### DIFF
--- a/src/main/java/com/jaeychoi/dailyus/common/exception/ErrorCode.java
+++ b/src/main/java/com/jaeychoi/dailyus/common/exception/ErrorCode.java
@@ -11,7 +11,11 @@ public enum ErrorCode {
   FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_004",
       "You do not have permission to access this resource."),
   INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_005",
-      "Refresh token is invalid or expired.");
+      "Refresh token is invalid or expired."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_003", "User not found."),
+  SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "USR_004", "You cannot follow yourself."),
+  FOLLOW_ALREADY_EXISTS(HttpStatus.CONFLICT, "USR_005", "Follow relationship already exists."),
+  FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_006", "Follow relationship not found.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/jaeychoi/dailyus/user/controller/UserController.java
+++ b/src/main/java/com/jaeychoi/dailyus/user/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.jaeychoi.dailyus.user.controller;
+
+import com.jaeychoi.dailyus.auth.annotation.AuthRequired;
+import com.jaeychoi.dailyus.auth.annotation.AuthenticatedUser;
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.common.web.ApiResponse;
+import com.jaeychoi.dailyus.user.dto.UserFollowResponse;
+import com.jaeychoi.dailyus.user.service.UserFollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserFollowService userFollowService;
+
+  @PostMapping("/{userId}/follow")
+  @ResponseStatus(HttpStatus.CREATED)
+  @AuthRequired
+  public ApiResponse<UserFollowResponse> follow(
+      @AuthenticatedUser CurrentUser user,
+      @PathVariable("userId") Long targetUserId) {
+    UserFollowResponse response = userFollowService.follow(user.userId(), targetUserId);
+    return ApiResponse.success(response);
+  }
+
+  @DeleteMapping("/{userId}/follow")
+  @AuthRequired
+  public ApiResponse<UserFollowResponse> unfollow(
+      @AuthenticatedUser CurrentUser user,
+      @PathVariable("userId") Long targetUserId) {
+    UserFollowResponse response = userFollowService.unfollow(user.userId(), targetUserId);
+    return ApiResponse.success(response);
+  }
+}

--- a/src/main/java/com/jaeychoi/dailyus/user/dto/UserFollowResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/user/dto/UserFollowResponse.java
@@ -1,0 +1,10 @@
+package com.jaeychoi.dailyus.user.dto;
+
+public record UserFollowResponse(
+    Long followee,
+    boolean following,
+    Long followerCount,
+    Long followeeCount
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/user/mapper/UserFollowMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/user/mapper/UserFollowMapper.java
@@ -1,0 +1,13 @@
+package com.jaeychoi.dailyus.user.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserFollowMapper {
+
+  boolean existsByFollowerAndFollowee(Long follower, Long followee);
+
+  void insert(Long follower, Long followee);
+
+  int delete(Long follower, Long followee);
+}

--- a/src/main/java/com/jaeychoi/dailyus/user/mapper/UserMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/user/mapper/UserMapper.java
@@ -6,13 +6,24 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface UserMapper {
 
-    boolean existsActiveByEmail(String email);
 
-    boolean existsActiveByNickname(String nickname);
+  boolean existsActiveByEmail(String email);
 
-    User findActiveById(Long userId);
+  boolean existsActiveByNickname(String nickname);
 
-    User findActiveByEmail(String email);
+  User findActiveById(Long userId);
 
-    void insert(User user);
+  User findActiveByEmail(String email);
+
+  boolean existsActiveById(Long userId);
+
+  void incrementFollowerCount(Long userId);
+
+  void incrementFolloweeCount(Long userId);
+
+  void decrementFollowerCount(Long userId);
+
+  void decrementFolloweeCount(Long userId);
+
+  void insert(User user);
 }

--- a/src/main/java/com/jaeychoi/dailyus/user/service/UserFollowService.java
+++ b/src/main/java/com/jaeychoi/dailyus/user/service/UserFollowService.java
@@ -1,0 +1,74 @@
+package com.jaeychoi.dailyus.user.service;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.user.domain.User;
+import com.jaeychoi.dailyus.user.dto.UserFollowResponse;
+import com.jaeychoi.dailyus.user.mapper.UserFollowMapper;
+import com.jaeychoi.dailyus.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFollowService {
+
+  private final UserMapper userMapper;
+  private final UserFollowMapper userFollowMapper;
+
+  @Transactional
+  public UserFollowResponse follow(Long follower, Long followee) {
+    validateFollowRequest(follower, followee);
+
+    if (userFollowMapper.existsByFollowerAndFollowee(follower, followee)) {
+      throw new BaseException(ErrorCode.FOLLOW_ALREADY_EXISTS);
+    }
+
+    userFollowMapper.insert(follower, followee);
+    userMapper.incrementFolloweeCount(follower);
+    userMapper.incrementFollowerCount(followee);
+
+    User targetUser = getActiveUser(followee);
+    return new UserFollowResponse(followee, true, targetUser.getFollowerCount(),
+        targetUser.getFolloweeCount());
+  }
+
+  @Transactional
+  public UserFollowResponse unfollow(Long follower, Long followee) {
+    validateTargetUsers(follower, followee);
+
+    int deletedCount = userFollowMapper.delete(follower, followee);
+    if (deletedCount == 0) {
+      throw new BaseException(ErrorCode.FOLLOW_NOT_FOUND);
+    }
+
+    userMapper.decrementFolloweeCount(follower);
+    userMapper.decrementFollowerCount(followee);
+
+    User targetUser = getActiveUser(followee);
+    return new UserFollowResponse(followee, false, targetUser.getFollowerCount(),
+        targetUser.getFolloweeCount());
+  }
+
+  private void validateFollowRequest(Long follower, Long followee) {
+    if (follower.equals(followee)) {
+      throw new BaseException(ErrorCode.SELF_FOLLOW_NOT_ALLOWED);
+    }
+    validateTargetUsers(follower, followee);
+  }
+
+  private void validateTargetUsers(Long follower, Long followee) {
+    if (!userMapper.existsActiveById(follower) || !userMapper.existsActiveById(followee)) {
+      throw new BaseException(ErrorCode.USER_NOT_FOUND);
+    }
+  }
+
+  private User getActiveUser(Long userId) {
+    User user = userMapper.findActiveById(userId);
+    if (user == null) {
+      throw new BaseException(ErrorCode.USER_NOT_FOUND);
+    }
+    return user;
+  }
+}

--- a/src/main/resources/mapper/user/UserFollowMapper.xml
+++ b/src/main/resources/mapper/user/UserFollowMapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jaeychoi.dailyus.user.mapper.UserFollowMapper">
+
+    <select id="existsByFollowerAndFollowee" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1
+            FROM user_follow
+            WHERE follower = #{follower}
+              AND followee = #{followee}
+        )
+    </select>
+
+    <insert id="insert">
+        INSERT INTO user_follow (
+            follower,
+            followee
+        ) VALUES (
+            #{follower},
+            #{followee}
+        )
+    </insert>
+
+    <delete id="delete">
+        DELETE FROM user_follow
+        WHERE follower = #{follower}
+          AND followee = #{followee}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -69,27 +69,63 @@
           AND deleted_at IS NULL
     </select>
 
+    <select id="existsActiveById" parameterType="long" resultType="boolean">
+      SELECT EXISTS(
+        SELECT 1
+        FROM users
+        WHERE user_id = #{userId}
+          AND deleted_at IS NULL
+      )
+    </select>
+
+    <update id="incrementFollowerCount" parameterType="long">
+      UPDATE users
+      SET follower_count = follower_count + 1
+      WHERE user_id = #{userId}
+        AND deleted_at IS NULL
+    </update>
+
+    <update id="incrementFolloweeCount" parameterType="long">
+      UPDATE users
+      SET followee_count = followee_count + 1
+      WHERE user_id = #{userId}
+        AND deleted_at IS NULL
+    </update>
+
+    <update id="decrementFollowerCount" parameterType="long">
+      UPDATE users
+      SET follower_count = follower_count - 1
+      WHERE user_id = #{userId}
+        AND deleted_at IS NULL
+        AND follower_count > 0
+    </update>
+
+    <update id="decrementFolloweeCount" parameterType="long">
+      UPDATE users
+      SET followee_count = followee_count - 1
+      WHERE user_id = #{userId}
+        AND deleted_at IS NULL
+        AND followee_count > 0
+    </update>
+
     <insert id="insert"
             parameterType="com.jaeychoi.dailyus.user.domain.User"
             useGeneratedKeys="true"
             keyProperty="userId">
-        INSERT INTO users (
-            email,
-            password,
-            nickname,
-            follower_count,
-            followee_count,
-            profile_image,
-            deleted_at
-        ) VALUES (
-            #{email},
-            #{password},
-            #{nickname},
-            #{followerCount},
-            #{followeeCount},
-            #{profileImage},
-            #{deletedAt}
-        )
+      INSERT INTO users (email,
+                         password,
+                         nickname,
+                         follower_count,
+                         followee_count,
+                         profile_image,
+                         deleted_at)
+      VALUES (#{email},
+              #{password},
+              #{nickname},
+              #{followerCount},
+              #{followeeCount},
+              #{profileImage},
+              #{deletedAt})
     </insert>
 
 </mapper>

--- a/src/test/java/com/jaeychoi/dailyus/user/controller/UserControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/user/controller/UserControllerTest.java
@@ -1,0 +1,88 @@
+package com.jaeychoi.dailyus.user.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.common.exception.GlobalExceptionHandler;
+import com.jaeychoi.dailyus.common.web.AuthRequestAttributes;
+import com.jaeychoi.dailyus.common.web.AuthenticatedUserArgumentResolver;
+import com.jaeychoi.dailyus.user.dto.UserFollowResponse;
+import com.jaeychoi.dailyus.user.service.UserFollowService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+  @Mock
+  private UserFollowService userFollowService;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userFollowService))
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .setCustomArgumentResolvers(new AuthenticatedUserArgumentResolver())
+        .setMessageConverters(new JacksonJsonHttpMessageConverter())
+        .build();
+  }
+
+  @Test
+  void followReturnsCreatedResponse() throws Exception {
+    UserFollowResponse response = new UserFollowResponse(2L, true, 3L, 1L);
+    when(userFollowService.follow(1L, 2L)).thenReturn(response);
+
+    mockMvc.perform(post("/api/v1/users/2/follow")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user")))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.data.followee").value(2L))
+        .andExpect(jsonPath("$.data.following").value(true))
+        .andExpect(jsonPath("$.data.followerCount").value(3L))
+        .andExpect(jsonPath("$.data.followeeCount").value(1L));
+  }
+
+  @Test
+  void unfollowReturnsOkResponse() throws Exception {
+    UserFollowResponse response = new UserFollowResponse(2L, false, 2L, 1L);
+    when(userFollowService.unfollow(1L, 2L)).thenReturn(response);
+
+    mockMvc.perform(delete("/api/v1/users/2/follow")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.data.followee").value(2L))
+        .andExpect(jsonPath("$.data.following").value(false))
+        .andExpect(jsonPath("$.data.followerCount").value(2L))
+        .andExpect(jsonPath("$.data.followeeCount").value(1L));
+  }
+
+  @Test
+  void followReturnsConflictWhenRelationshipAlreadyExists() throws Exception {
+    when(userFollowService.follow(anyLong(), anyLong()))
+        .thenThrow(new BaseException(ErrorCode.FOLLOW_ALREADY_EXISTS));
+
+    mockMvc.perform(post("/api/v1/users/2/follow")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user")))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(ErrorCode.FOLLOW_ALREADY_EXISTS.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.FOLLOW_ALREADY_EXISTS.getMessage()));
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/user/mapper/UserFollowMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/user/mapper/UserFollowMapperTest.java
@@ -1,0 +1,112 @@
+package com.jaeychoi.dailyus.user.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+
+@MybatisTest
+class UserFollowMapperTest {
+
+  @Autowired
+  private UserFollowMapper userFollowMapper;
+
+  @Autowired
+  private UserMapper userMapper;
+
+  @Autowired
+  private DataSource dataSource;
+
+  @Test
+  void insertAndDeleteManageFollowRelationship() throws Exception {
+    // given
+    Long followerId = insertUser("follower@example.com", "follower");
+    Long followeeId = insertUser("followee@example.com", "followee");
+
+    // when
+    userFollowMapper.insert(followerId, followeeId);
+    int deletedCount = userFollowMapper.delete(followerId, followeeId);
+
+    // then
+    assertThat(deletedCount).isEqualTo(1);
+    assertThat(rawExistsByFollowerAndFollowee(followerId, followeeId)).isFalse();
+  }
+
+  @Test
+  void userMapperCountUpdatesReflectInLoadedUser() throws Exception {
+    // given
+    Long followerId = insertUser("actor@example.com", "actor");
+    Long followeeId = insertUser("target@example.com", "target");
+
+    // when
+    userMapper.incrementFolloweeCount(followerId);
+    userMapper.incrementFollowerCount(followeeId);
+    userMapper.decrementFolloweeCount(followerId);
+    userMapper.decrementFollowerCount(followeeId);
+
+    // then
+    assertThat(userMapper.findActiveById(followerId).getFolloweeCount()).isZero();
+    assertThat(userMapper.findActiveById(followeeId).getFollowerCount()).isZero();
+  }
+
+  private Long insertUser(String email, String nickname) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO users (
+                    email,
+                    password,
+                    nickname,
+                    follower_count,
+                    followee_count,
+                    profile_image,
+                    deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+            new String[]{"user_id"}
+        )) {
+      statement.setString(1, email);
+      statement.setString(2, "encoded-password");
+      statement.setString(3, nickname);
+      statement.setLong(4, 0L);
+      statement.setLong(5, 0L);
+      statement.setString(6, null);
+      statement.setTimestamp(7, null);
+      statement.executeUpdate();
+
+      try (var generatedKeys = statement.getGeneratedKeys()) {
+        generatedKeys.next();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private boolean rawExistsByFollowerAndFollowee(Long followerId, Long followeeId)
+      throws Exception {
+    Connection connection = DataSourceUtils.getConnection(dataSource);
+    try (PreparedStatement statement = connection.prepareStatement(
+        """
+            SELECT EXISTS(
+                SELECT 1
+                FROM user_follow
+                WHERE follower = ?
+                  AND followee = ?
+            )
+            """
+    )) {
+      statement.setLong(1, followerId);
+      statement.setLong(2, followeeId);
+
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertThat(resultSet.next()).isTrue();
+        return resultSet.getBoolean(1);
+      }
+    }
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/user/mapper/UserMapperTest.java
@@ -41,6 +41,25 @@ class UserMapperTest {
   }
 
   @Test
+  void existsActiveByIdReturnsTrueOnlyForActiveUsers() throws Exception {
+    // given
+    Long activeUserId = insertUser("active-id@example.com", "active-id-user", null);
+    Long deletedUserId = insertUser(
+        "deleted-id@example.com",
+        "deleted-id-user",
+        LocalDateTime.of(2026, 3, 26, 10, 0)
+    );
+
+    // when
+    boolean activeExists = userMapper.existsActiveById(activeUserId);
+    boolean deletedExists = userMapper.existsActiveById(deletedUserId);
+
+    // then
+    assertThat(activeExists).isTrue();
+    assertThat(deletedExists).isFalse();
+  }
+
+  @Test
   void insertPersistsUserAndSetsGeneratedKey() {
     // given
     User user = User.builder()
@@ -58,7 +77,7 @@ class UserMapperTest {
     assertThat(userMapper.existsActiveByNickname("new-user")).isTrue();
   }
 
-  private void insertUser(String email, String nickname, LocalDateTime deletedAt) throws Exception {
+  private Long insertUser(String email, String nickname, LocalDateTime deletedAt) throws Exception {
     try (Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(
             """
@@ -71,7 +90,8 @@ class UserMapperTest {
                     profile_image,
                     deleted_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                """
+                """,
+            PreparedStatement.RETURN_GENERATED_KEYS
         )) {
       statement.setString(1, email);
       statement.setString(2, "encoded-password");
@@ -81,6 +101,11 @@ class UserMapperTest {
       statement.setString(6, null);
       statement.setTimestamp(7, deletedAt == null ? null : Timestamp.valueOf(deletedAt));
       statement.executeUpdate();
+
+      try (var generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
     }
   }
 }

--- a/src/test/java/com/jaeychoi/dailyus/user/service/UserFollowServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/user/service/UserFollowServiceTest.java
@@ -1,0 +1,144 @@
+package com.jaeychoi.dailyus.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.user.domain.User;
+import com.jaeychoi.dailyus.user.dto.UserFollowResponse;
+import com.jaeychoi.dailyus.user.mapper.UserFollowMapper;
+import com.jaeychoi.dailyus.user.mapper.UserMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserFollowServiceTest {
+
+  @Mock
+  private UserMapper userMapper;
+
+  @Mock
+  private UserFollowMapper userFollowMapper;
+
+  @InjectMocks
+  private UserFollowService userFollowService;
+
+  @Test
+  void followCreatesRelationshipAndUpdatesCounts() {
+    // given
+    Long loginUserId = 1L;
+    Long targetUserId = 2L;
+    User targetUser = User.builder()
+        .userId(targetUserId)
+        .followerCount(3L)
+        .followeeCount(1L)
+        .build();
+
+    when(userMapper.existsActiveById(loginUserId)).thenReturn(true);
+    when(userMapper.existsActiveById(targetUserId)).thenReturn(true);
+    when(userFollowMapper.existsByFollowerAndFollowee(loginUserId, targetUserId)).thenReturn(false);
+    when(userMapper.findActiveById(targetUserId)).thenReturn(targetUser);
+
+    // when
+    UserFollowResponse response = userFollowService.follow(loginUserId, targetUserId);
+
+    // then
+    verify(userFollowMapper).insert(loginUserId, targetUserId);
+    verify(userMapper).incrementFolloweeCount(loginUserId);
+    verify(userMapper).incrementFollowerCount(targetUserId);
+    assertThat(response.followee()).isEqualTo(targetUserId);
+    assertThat(response.following()).isTrue();
+    assertThat(response.followerCount()).isEqualTo(3L);
+    assertThat(response.followeeCount()).isEqualTo(1L);
+  }
+
+  @Test
+  void followThrowsWhenTargetIsSelf() {
+    // given
+    Long loginUserId = 1L;
+
+    // when
+    // then
+    assertThatThrownBy(() -> userFollowService.follow(loginUserId, loginUserId))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.SELF_FOLLOW_NOT_ALLOWED);
+
+    verify(userMapper, never()).existsActiveById(loginUserId);
+    verify(userFollowMapper, never()).insert(loginUserId, loginUserId);
+  }
+
+  @Test
+  void followThrowsWhenRelationshipAlreadyExists() {
+    // given
+    Long loginUserId = 1L;
+    Long targetUserId = 2L;
+    when(userMapper.existsActiveById(loginUserId)).thenReturn(true);
+    when(userMapper.existsActiveById(targetUserId)).thenReturn(true);
+    when(userFollowMapper.existsByFollowerAndFollowee(loginUserId, targetUserId)).thenReturn(true);
+
+    // when
+    // then
+    assertThatThrownBy(() -> userFollowService.follow(loginUserId, targetUserId))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.FOLLOW_ALREADY_EXISTS);
+
+    verify(userFollowMapper, never()).insert(loginUserId, targetUserId);
+  }
+
+  @Test
+  void unfollowDeletesRelationshipAndUpdatesCounts() {
+    // given
+    Long loginUserId = 1L;
+    Long targetUserId = 2L;
+    User targetUser = User.builder()
+        .userId(targetUserId)
+        .followerCount(2L)
+        .followeeCount(1L)
+        .build();
+
+    when(userMapper.existsActiveById(loginUserId)).thenReturn(true);
+    when(userMapper.existsActiveById(targetUserId)).thenReturn(true);
+    when(userFollowMapper.delete(loginUserId, targetUserId)).thenReturn(1);
+    when(userMapper.findActiveById(targetUserId)).thenReturn(targetUser);
+
+    // when
+    UserFollowResponse response = userFollowService.unfollow(loginUserId, targetUserId);
+
+    // then
+    verify(userMapper).decrementFolloweeCount(loginUserId);
+    verify(userMapper).decrementFollowerCount(targetUserId);
+    assertThat(response.followee()).isEqualTo(targetUserId);
+    assertThat(response.following()).isFalse();
+    assertThat(response.followerCount()).isEqualTo(2L);
+    assertThat(response.followeeCount()).isEqualTo(1L);
+  }
+
+  @Test
+  void unfollowThrowsWhenRelationshipDoesNotExist() {
+    // given
+    Long loginUserId = 1L;
+    Long targetUserId = 2L;
+    when(userMapper.existsActiveById(loginUserId)).thenReturn(true);
+    when(userMapper.existsActiveById(targetUserId)).thenReturn(true);
+    when(userFollowMapper.delete(loginUserId, targetUserId)).thenReturn(0);
+
+    // when
+    // then
+    assertThatThrownBy(() -> userFollowService.unfollow(loginUserId, targetUserId))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.FOLLOW_NOT_FOUND);
+
+    verify(userMapper, never()).decrementFolloweeCount(loginUserId);
+    verify(userMapper, never()).decrementFollowerCount(targetUserId);
+  }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -14,6 +14,17 @@ CREATE TABLE users (
     CONSTRAINT uk_users_nickname UNIQUE (nickname)
 );
 
+CREATE TABLE user_follow (
+    follower BIGINT NOT NULL,
+    followee BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (follower, followee),
+    CONSTRAINT fk_user_follow_follower
+        FOREIGN KEY (follower) REFERENCES users (user_id),
+    CONSTRAINT fk_user_follow_followee
+        FOREIGN KEY (followee) REFERENCES users (user_id)
+);
+
 CREATE TABLE user_groups (
     group_id BIGINT NOT NULL AUTO_INCREMENT,
     name VARCHAR(100) NOT NULL,


### PR DESCRIPTION
  ## ✨ 작업 내용
  - `POST /api/v1/users/{userId}/follow` 팔로우 엔드포인트 추가
  - `DELETE /api/v1/users/{userId}/follow` 언팔로우 엔드포인트 추가
  - 자기 자신 팔로우 방지, 대상 사용자 존재 여부 검증, 중복 팔로우/미존재 관계 예외 처리 구현
  - 팔로우/언팔로우 시 follower/followee 카운트 증감 로직 추가
  - `UserFollowService`, `UserController` 및 관련 DTO 구현
  - 유저 팔로우/언팔로우 테스트 작성

  ## 관련 이슈
  - closes #49 

  ## 스크린샷 / 참고 자료
  <!-- 필요한 경우 첨부 -->