### PR TITLE
[Feat] 피드 조회 기능 구현

### DIFF
--- a/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
@@ -6,13 +6,17 @@ import com.jaeychoi.dailyus.auth.domain.CurrentUser;
 import com.jaeychoi.dailyus.common.web.ApiResponse;
 import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
 import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
 import com.jaeychoi.dailyus.post.service.PostCreateService;
+import com.jaeychoi.dailyus.post.service.PostFeedService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +26,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
   private final PostCreateService postCreateService;
+  private final PostFeedService postFeedService;
+
+  @GetMapping
+  @AuthRequired
+  public ApiResponse<PostFeedResponse> getFeed(@AuthenticatedUser CurrentUser user,
+      @RequestParam(required = false, defaultValue = "0") Long page,
+      @RequestParam(required = false, defaultValue = "10") Long size) {
+    return ApiResponse.success(postFeedService.getFeed(user.userId(), page, size));
+  }
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedItemResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedItemResponse.java
@@ -1,0 +1,17 @@
+package com.jaeychoi.dailyus.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostFeedItemResponse(
+    Long postId,
+    Long userId,
+    String nickname,
+    String profileImage,
+    String content,
+    List<String> imageUrls,
+    Long likeCount,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedResponse.java
@@ -1,0 +1,10 @@
+package com.jaeychoi.dailyus.post.dto;
+
+import java.util.List;
+
+public record PostFeedResponse(
+    List<PostFeedItemResponse> items,
+    Long page,
+    Long size) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedRow.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedRow.java
@@ -1,0 +1,15 @@
+package com.jaeychoi.dailyus.post.dto;
+
+import java.time.LocalDateTime;
+
+public record PostFeedRow(
+    Long postId,
+    Long userId,
+    String nickname,
+    String profileImage,
+    String content,
+    Long likeCount,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostImageRow.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostImageRow.java
@@ -1,0 +1,5 @@
+package com.jaeychoi.dailyus.post.dto;
+
+public record PostImageRow(Long postId, String imageUrl) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
@@ -1,9 +1,10 @@
 package com.jaeychoi.dailyus.post.mapper;
 
 import com.jaeychoi.dailyus.post.domain.Post;
+import com.jaeychoi.dailyus.post.dto.PostFeedRow;
+import com.jaeychoi.dailyus.post.dto.PostImageRow;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface PostMapper {
@@ -11,4 +12,12 @@ public interface PostMapper {
   void insert(Post post);
 
   void insertImages(Long postId, List<String> imageUrls);
+
+  boolean existsFeedPosts(Long userId);
+
+  List<PostFeedRow> findFeedPosts(Long userId, Long size, Long offset);
+
+  List<PostFeedRow> findRecentFeedPosts(Long size, Long offset);
+
+  List<PostImageRow> findImagesByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
@@ -39,7 +39,7 @@ public class PostFeedService {
         ))
         .toList();
 
-    return new PostFeedResponse(items, page, size);
+    return new PostFeedResponse(items, pageValue, sizeValue);
 
   }
 

--- a/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
@@ -1,0 +1,72 @@
+package com.jaeychoi.dailyus.post.service;
+
+import com.jaeychoi.dailyus.post.dto.PostFeedItemResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedRow;
+import com.jaeychoi.dailyus.post.dto.PostImageRow;
+import com.jaeychoi.dailyus.post.mapper.PostMapper;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostFeedService {
+
+  private final PostMapper postMapper;
+
+  public PostFeedResponse getFeed(Long userId, Long page, Long size) {
+    Long pageValue = page == null ? 0L : page;
+    Long sizeValue = size == null ? 10L : size;
+
+    List<PostFeedRow> rows = loadFeedPosts(userId, pageValue, sizeValue);
+    Map<Long, List<String>> imageUrlsByPostId = loadImageUrlsByPostId(rows);
+
+    List<PostFeedItemResponse> items = rows.stream()
+        .map(row -> new PostFeedItemResponse(
+            row.postId(),
+            row.userId(),
+            row.nickname(),
+            row.profileImage(),
+            row.content(),
+            imageUrlsByPostId.getOrDefault(row.postId(), Collections.emptyList()),
+            row.likeCount(),
+            row.createdAt()
+        ))
+        .toList();
+
+    return new PostFeedResponse(items, page, size);
+
+  }
+
+  private List<PostFeedRow> loadFeedPosts(Long userId, Long page, Long size) {
+    Long offset = page * size;
+
+    if (postMapper.existsFeedPosts(userId)) {
+      return postMapper.findFeedPosts(userId, size, offset);
+    }
+
+    return postMapper.findRecentFeedPosts(size, offset);
+  }
+
+  private Map<Long, List<String>> loadImageUrlsByPostId(List<PostFeedRow> rows) {
+    if (rows.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    List<Long> postIds = rows.stream()
+        .map(PostFeedRow::postId)
+        .toList();
+
+    return postMapper.findImagesByPostIds(postIds).stream()
+        .collect(Collectors.groupingBy(
+            PostImageRow::postId,
+            LinkedHashMap::new,
+            Collectors.mapping(PostImageRow::imageUrl, Collectors.toList())
+        ));
+  }
+}

--- a/src/main/resources/mapper/post/PostMapper.xml
+++ b/src/main/resources/mapper/post/PostMapper.xml
@@ -71,8 +71,8 @@
         JOIN posts p ON p.user_id = u.user_id
         WHERE u.deleted_at IS NULL
         AND p.deleted_at IS NULL
-        ORDER BY p.created_at DESC
-        LIMIT #{size} OFFSET #{offset}
+        ORDER BY p.created_at DESC, p.post_id DESC
+          LIMIT #{size} OFFSET #{offset}
     </select>
     
     <select id="findRecentFeedPosts" resultMap="postFeedRowResultMap">
@@ -87,7 +87,7 @@
         JOIN users u ON u.user_id = p.user_id
         WHERE p.deleted_at IS NULL
         AND u.deleted_at IS NULL
-        ORDER BY p.created_at desc
+        ORDER BY p.created_at DESC, p.post_id DESC
         LIMIT #{size} OFFSET #{offset}
     </select>
 

--- a/src/main/resources/mapper/post/PostMapper.xml
+++ b/src/main/resources/mapper/post/PostMapper.xml
@@ -4,6 +4,107 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.jaeychoi.dailyus.post.mapper.PostMapper">
 
+    <resultMap id="postFeedRowResultMap" type="com.jaeychoi.dailyus.post.dto.PostFeedRow">
+        <constructor>
+            <idArg column="post_id" javaType="java.lang.Long"/>
+            <arg column="user_id" javaType="java.lang.Long"/>
+            <arg column="nickname" javaType="java.lang.String"/>
+            <arg column="profile_image" javaType="java.lang.String"/>
+            <arg column="content" javaType="java.lang.String"/>
+            <arg column="like_count" javaType="java.lang.Long"/>
+            <arg column="created_at" javaType="java.time.LocalDateTime"/>
+        </constructor>
+    </resultMap>
+
+    <resultMap id="postImageRowResultMap" type="com.jaeychoi.dailyus.post.dto.PostImageRow">
+        <constructor>
+            <arg column="post_id" javaType="java.lang.Long"/>
+            <arg column="image_url" javaType="java.lang.String"/>
+        </constructor>
+    </resultMap>
+
+    <select id="existsFeedPosts" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1
+            FROM (
+                     SELECT gm.user_id
+                     FROM group_members gm
+                     WHERE gm.group_id IN (
+                         SELECT my_group.group_id
+                         FROM group_members my_group
+                         WHERE my_group.user_id = #{userId}
+                     )
+                     UNION
+                     SELECT uf.followee
+                     FROM user_follow uf
+                     WHERE uf.follower = #{userId}
+                 ) related_users
+            INNER JOIN users u ON u.user_id = related_users.user_id
+            INNER JOIN posts p ON p.user_id = related_users.user_id
+            WHERE u.deleted_at IS NULL
+              AND p.deleted_at IS NULL
+        )
+    </select>
+
+    <select id="findFeedPosts" resultMap="postFeedRowResultMap">
+        SELECT p.post_id,
+               u.user_id,
+               u.nickname,
+               u.profile_image,
+               p.content,
+               p.like_count,
+               p.created_at
+        FROM (
+                 SELECT user_id
+                 FROM group_members
+                 WHERE group_id IN (
+                     SELECT m.group_id
+                     FROM group_members m
+                     WHERE m.user_id = #{userId}
+                 )
+                 UNION
+                 SELECT f.followee user_id
+                 FROM user_follow f
+                 WHERE f.follower = #{userId}
+             ) r
+        JOIN users u ON u.user_id = r.user_id
+        JOIN posts p ON p.user_id = u.user_id
+        WHERE u.deleted_at IS NULL
+        AND p.deleted_at IS NULL
+        ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+    
+    <select id="findRecentFeedPosts" resultMap="postFeedRowResultMap">
+        SELECT p.post_id,
+               u.user_id,
+               u.nickname,
+               u.profile_image,
+               p.content,
+               p.like_count,
+               p.created_at
+        FROM posts p
+        JOIN users u ON u.user_id = p.user_id
+        WHERE p.deleted_at IS NULL
+        AND u.deleted_at IS NULL
+        ORDER BY p.created_at desc
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <select id="findImagesByPostIds" resultMap="postImageRowResultMap">
+      SELECT i.post_id,
+      i.image_url
+      FROM post_images i
+      JOIN posts p ON p.post_id = i.post_id
+      WHERE i.deleted_at IS NULL
+      AND p.deleted_at IS NULL
+      AND i.post_id IN
+      <foreach collection="postIds" item="postId" open="(" separator="," close=")">
+        #{postId}
+      </foreach>
+      ORDER BY i.post_id, i.created_at
+    </select>
+
     <insert id="insert"
             parameterType="com.jaeychoi.dailyus.post.domain.Post"
             useGeneratedKeys="true"

--- a/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
@@ -3,17 +3,23 @@ package com.jaeychoi.dailyus.post.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jaeychoi.dailyus.auth.domain.CurrentUser;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
 import com.jaeychoi.dailyus.common.exception.GlobalExceptionHandler;
 import com.jaeychoi.dailyus.common.web.AuthRequestAttributes;
 import com.jaeychoi.dailyus.common.web.AuthenticatedUserArgumentResolver;
 import com.jaeychoi.dailyus.post.dto.PostCreateRequest;
 import com.jaeychoi.dailyus.post.dto.PostCreateResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedItemResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
 import com.jaeychoi.dailyus.post.service.PostCreateService;
+import com.jaeychoi.dailyus.post.service.PostFeedService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +39,9 @@ class PostControllerTest {
   @Mock
   private PostCreateService postCreateService;
 
+  @Mock
+  private PostFeedService postFeedService;
+
   private MockMvc mockMvc;
   private ObjectMapper objectMapper;
 
@@ -41,7 +50,7 @@ class PostControllerTest {
     LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
     validator.afterPropertiesSet();
 
-    mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postCreateService))
+    mockMvc = MockMvcBuilders.standaloneSetup(new PostController(postCreateService, postFeedService))
         .setControllerAdvice(new GlobalExceptionHandler())
         .setCustomArgumentResolvers(new AuthenticatedUserArgumentResolver())
         .setValidator(validator)
@@ -90,5 +99,43 @@ class PostControllerTest {
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+  }
+
+  @Test
+  void getFeedReturnsOkResponse() throws Exception {
+    PostFeedResponse response = new PostFeedResponse(
+        List.of(new PostFeedItemResponse(
+            10L,
+            2L,
+            "author",
+            "https://example.com/profile.png",
+            "feed content",
+            List.of("https://cdn.example.com/1.png", "https://cdn.example.com/2.png"),
+            3L,
+            LocalDateTime.of(2026, 4, 6, 10, 0)
+        )),
+        0L,
+        10L
+    );
+    when(postFeedService.getFeed(1L, 0L, 10L)).thenReturn(response);
+
+    mockMvc.perform(get("/api/v1/posts")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.data.page").value(0L))
+        .andExpect(jsonPath("$.data.size").value(10L))
+        .andExpect(jsonPath("$.data.items[0].postId").value(10L))
+        .andExpect(jsonPath("$.data.items[0].imageUrls[0]").value("https://cdn.example.com/1.png"));
+  }
+
+  @Test
+  void getFeedReturnsUnauthorizedWhenCurrentUserMissing() throws Exception {
+    mockMvc.perform(get("/api/v1/posts"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()))
+        .andExpect(jsonPath("$.data").doesNotExist());
   }
 }

--- a/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
@@ -2,12 +2,17 @@ package com.jaeychoi.dailyus.post.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jaeychoi.dailyus.post.dto.PostFeedRow;
+import com.jaeychoi.dailyus.post.dto.PostImageRow;
 import com.jaeychoi.dailyus.post.domain.Post;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -57,6 +62,106 @@ class PostMapperTest {
     assertThat(countPostImages(postId)).isEqualTo(2);
     assertThat(loadPostImageUrls(postId))
         .containsExactlyInAnyOrderElementsOf(imageUrls);
+  }
+
+  @Test
+  void findFeedPostsReturnsPostsFromFolloweesAndGroupMembers() throws Exception {
+    // given
+    Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
+    Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
+    Long groupMemberId = insertUser(uniqueEmail("group-member"), uniqueNickname("group-member"));
+    Long outsiderId = insertUser(uniqueEmail("outsider"), uniqueNickname("outsider"));
+    insertFollow(loginUserId, followeeId);
+    Long groupId = insertGroup(loginUserId, "daily-us");
+    insertGroupMember(groupId, loginUserId);
+    insertGroupMember(groupId, groupMemberId);
+    Long followeePostId = insertPost(followeeId, "followee post");
+    Long groupMemberPostId = insertPost(groupMemberId, "group member post");
+    insertPost(outsiderId, "outsider post");
+
+    // when
+    List<PostFeedRow> rows = postMapper.findFeedPosts(loginUserId, 10L, 0L);
+
+    // then
+    assertThat(rows).extracting(PostFeedRow::postId)
+        .contains(followeePostId, groupMemberPostId)
+        .doesNotContainNull();
+    assertThat(rows).extracting(PostFeedRow::userId)
+        .contains(followeeId, groupMemberId)
+        .doesNotContain(outsiderId);
+  }
+
+  @Test
+  void existsFeedPostsReturnsTrueWhenRelatedUsersHavePosts() throws Exception {
+    // given
+    Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
+    Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
+    insertFollow(loginUserId, followeeId);
+    insertPost(followeeId, "followee post");
+
+    // when
+    boolean exists = postMapper.existsFeedPosts(loginUserId);
+
+    // then
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  void existsFeedPostsReturnsFalseWhenRelatedUsersHaveNoPosts() throws Exception {
+    // given
+    Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
+    Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
+    insertFollow(loginUserId, followeeId);
+
+    // when
+    boolean exists = postMapper.existsFeedPosts(loginUserId);
+
+    // then
+    assertThat(exists).isFalse();
+  }
+
+  @Test
+  void findRecentFeedPostsReturnsRecentPostsOrderedByCreatedAtDesc() throws Exception {
+    // given
+    Long firstUserId = insertUser(uniqueEmail("first"), uniqueNickname("first"));
+    Long secondUserId = insertUser(uniqueEmail("second"), uniqueNickname("second"));
+    Long olderPostId = insertPost(firstUserId, "older post");
+    Long newerPostId = insertPost(secondUserId, "newer post");
+    updatePostCreatedAt(olderPostId, LocalDateTime.of(2026, 4, 6, 8, 0));
+    updatePostCreatedAt(newerPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+
+    // when
+    List<PostFeedRow> rows = postMapper.findRecentFeedPosts(10L, 0L);
+
+    // then
+    assertThat(rows).extracting(PostFeedRow::postId)
+        .containsSequence(newerPostId, olderPostId);
+  }
+
+  @Test
+  void findImagesByPostIdsReturnsImagesGroupedInCreatedOrder() throws Exception {
+    // given
+    Long userId = insertUser(uniqueEmail("author"), uniqueNickname("author"));
+    Long firstPostId = insertPost(userId, "first post");
+    Long secondPostId = insertPost(userId, "second post");
+    postMapper.insertImages(firstPostId, List.of(
+        "https://cdn.example.com/first-1.png",
+        "https://cdn.example.com/first-2.png"
+    ));
+    postMapper.insertImages(secondPostId, List.of("https://cdn.example.com/second-1.png"));
+
+    // when
+    List<PostImageRow> rows = postMapper.findImagesByPostIds(List.of(firstPostId, secondPostId));
+
+    // then
+    assertThat(rows).extracting(PostImageRow::postId)
+        .containsExactly(firstPostId, firstPostId, secondPostId);
+    assertThat(rows).extracting(PostImageRow::imageUrl)
+        .containsExactly(
+            "https://cdn.example.com/first-1.png",
+            "https://cdn.example.com/first-2.png",
+            "https://cdn.example.com/second-1.png"
+        );
   }
 
   private Long insertUser(String email, String nickname) throws Exception {
@@ -113,6 +218,77 @@ class PostMapperTest {
     }
   }
 
+  private void insertFollow(Long followerId, Long followeeId) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO user_follow (
+                    follower,
+                    followee
+                ) VALUES (?, ?)
+                """
+        )) {
+      statement.setLong(1, followerId);
+      statement.setLong(2, followeeId);
+      statement.executeUpdate();
+    }
+  }
+
+  private Long insertGroup(Long ownerId, String name) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO user_groups (
+                    name,
+                    intro,
+                    group_image,
+                    owner_id,
+                    deleted_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+            new String[]{"group_id"}
+        )) {
+      statement.setString(1, name);
+      statement.setString(2, "intro");
+      statement.setString(3, null);
+      statement.setLong(4, ownerId);
+      statement.setTimestamp(5, null);
+      statement.executeUpdate();
+
+      try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
+        assertThat(generatedKeys.next()).isTrue();
+        return generatedKeys.getLong(1);
+      }
+    }
+  }
+
+  private void insertGroupMember(Long groupId, Long userId) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            """
+                INSERT INTO group_members (
+                    group_id,
+                    user_id
+                ) VALUES (?, ?)
+                """
+        )) {
+      statement.setLong(1, groupId);
+      statement.setLong(2, userId);
+      statement.executeUpdate();
+    }
+  }
+
+  private void updatePostCreatedAt(Long postId, LocalDateTime createdAt) throws Exception {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(
+            "UPDATE posts SET created_at = ? WHERE post_id = ?"
+        )) {
+      statement.setTimestamp(1, Timestamp.valueOf(createdAt));
+      statement.setLong(2, postId);
+      statement.executeUpdate();
+    }
+  }
+
   private int countPosts(Long postId) throws Exception {
     Connection connection = DataSourceUtils.getConnection(dataSource);
     try (PreparedStatement statement = connection.prepareStatement(
@@ -153,5 +329,13 @@ class PostMapperTest {
         return imageUrls;
       }
     }
+  }
+
+  private String uniqueEmail(String prefix) {
+    return prefix + "-" + UUID.randomUUID() + "@example.com";
+  }
+
+  private String uniqueNickname(String prefix) {
+    return prefix + "-" + UUID.randomUUID();
   }
 }

--- a/src/test/java/com/jaeychoi/dailyus/post/service/PostFeedServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/service/PostFeedServiceTest.java
@@ -1,0 +1,119 @@
+package com.jaeychoi.dailyus.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
+import com.jaeychoi.dailyus.post.dto.PostFeedRow;
+import com.jaeychoi.dailyus.post.dto.PostImageRow;
+import com.jaeychoi.dailyus.post.mapper.PostMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostFeedServiceTest {
+
+  @Mock
+  private PostMapper postMapper;
+
+  @InjectMocks
+  private PostFeedService postFeedService;
+
+  @Test
+  void getFeedReturnsPersonalizedFeedWithImages() {
+    // given
+    Long userId = 1L;
+    PostFeedRow firstRow = new PostFeedRow(
+        10L,
+        2L,
+        "author-1",
+        "https://example.com/profile-1.png",
+        "content-1",
+        3L,
+        LocalDateTime.of(2026, 4, 6, 10, 0)
+    );
+    PostFeedRow secondRow = new PostFeedRow(
+        9L,
+        3L,
+        "author-2",
+        "https://example.com/profile-2.png",
+        "content-2",
+        1L,
+        LocalDateTime.of(2026, 4, 6, 9, 0)
+    );
+    when(postMapper.existsFeedPosts(userId)).thenReturn(true);
+    when(postMapper.findFeedPosts(userId, 10L, 0L)).thenReturn(List.of(firstRow, secondRow));
+    when(postMapper.findImagesByPostIds(List.of(10L, 9L))).thenReturn(List.of(
+        new PostImageRow(10L, "https://cdn.example.com/10-1.png"),
+        new PostImageRow(10L, "https://cdn.example.com/10-2.png"),
+        new PostImageRow(9L, "https://cdn.example.com/9-1.png")
+    ));
+
+    // when
+    PostFeedResponse response = postFeedService.getFeed(userId, 0L, 10L);
+
+    // then
+    verify(postMapper, never()).findRecentFeedPosts(10L, 0L);
+    assertThat(response.page()).isEqualTo(0L);
+    assertThat(response.size()).isEqualTo(10L);
+    assertThat(response.items()).hasSize(2);
+    assertThat(response.items().get(0).postId()).isEqualTo(10L);
+    assertThat(response.items().get(0).imageUrls())
+        .containsExactly("https://cdn.example.com/10-1.png", "https://cdn.example.com/10-2.png");
+    assertThat(response.items().get(1).postId()).isEqualTo(9L);
+    assertThat(response.items().get(1).imageUrls())
+        .containsExactly("https://cdn.example.com/9-1.png");
+  }
+
+  @Test
+  void getFeedReturnsRecentPostsWhenFeedPostsDoNotExist() {
+    // given
+    Long userId = 1L;
+    PostFeedRow recentRow = new PostFeedRow(
+        8L,
+        4L,
+        "recent-author",
+        null,
+        "recent-content",
+        0L,
+        LocalDateTime.of(2026, 4, 6, 8, 0)
+    );
+    when(postMapper.existsFeedPosts(userId)).thenReturn(false);
+    when(postMapper.findRecentFeedPosts(10L, 0L)).thenReturn(List.of(recentRow));
+    when(postMapper.findImagesByPostIds(List.of(8L))).thenReturn(List.of());
+
+    // when
+    PostFeedResponse response = postFeedService.getFeed(userId, 0L, 10L);
+
+    // then
+    verify(postMapper).findRecentFeedPosts(10L, 0L);
+    assertThat(response.items()).hasSize(1);
+    assertThat(response.items().get(0).postId()).isEqualTo(8L);
+  }
+
+  @Test
+  void getFeedReturnsEmptyItemsWhenFeedPostsExistButRequestedPageHasNoRows() {
+    // given
+    Long userId = 1L;
+    when(postMapper.existsFeedPosts(userId)).thenReturn(true);
+    when(postMapper.findFeedPosts(userId, 10L, 10L)).thenReturn(List.of());
+
+    // when
+    PostFeedResponse response = postFeedService.getFeed(userId, 1L, 10L);
+
+    // then
+    verify(postMapper, never()).findRecentFeedPosts(10L, 10L);
+    verify(postMapper, never()).findImagesByPostIds(anyList());
+    assertThat(response.items()).isEmpty();
+    assertThat(response.page()).isEqualTo(1L);
+    assertThat(response.size()).isEqualTo(10L);
+  }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 개인화 피드 조회 기능 구현
- 사용자가 팔로우한 사용자와 동일한 그룹에 속한 사용자의 게시글을 피드 대상 조회 구현
- 최신순으로 조회되도록 정렬 기준 적용
- 피드 조회 기능 테스트

## 🔗 관련 이슈
- closes #24 

## 📸 스크린샷 / 참고 자료
<!-- 필요한 경우 첨부 -->