### PR TITLE
[Test] Cursor기반 피드 조회 테스트

### DIFF
--- a/docs/03_Test/피드_조회_API_테스트_02/피드_조회_API_성능테스트_싱글.md
+++ b/docs/03_Test/피드_조회_API_테스트_02/피드_조회_API_성능테스트_싱글.md
@@ -1,0 +1,130 @@
+# 피드 조회 API 성능 테스트 (싱글, Cursor vs Offset)
+
+## 1. 목적
+
+`cursor` 기반 피드 조회와 기존 `offset` 기반 피드 조회보를 비교한다.
+
+- 실제 API 응답 시간
+- 동일 데이터셋에서 `offset` SQL과 `cursor` SQL의 실행 시간 및 `EXPLAIN ANALYZE`
+
+## 2. 비교 대상
+
+### 2.1 이전 Offset 방식
+
+- 컨트롤러: `GET /api/v1/posts?page={page}&size=10`
+- 기준 코드: `cba77c9^`, `0cc24c9^`
+- 핵심 SQL 차이
+  - 개인화 피드: `ORDER BY ... LIMIT #{size} OFFSET #{offset}`
+  - fallback 최근 피드: `ORDER BY ... LIMIT #{size} OFFSET #{offset}`
+
+### 2.2 현재 Cursor 방식
+
+- 컨트롤러: `GET /api/v1/posts?createdAt={lastCreatedAt}&postId={lastPostId}&size=10`
+- 현재 코드
+  - 서비스: `PostFeedService#getFeed`
+  - 쿼리: `PostMapper.findFeedPosts`, `PostMapper.findRecentFeedPosts`
+
+## 3. 테스트 환경
+
+- 애플리케이션: `http://localhost:8080`
+- DB: 로컬 MySQL
+- 데이터 규모
+  - 사용자 `300,000`
+  - 게시물 `3,000,000`
+  - 사용자당 평균 게시물 `10`
+- 인증 계정
+  - 일반 사용자: `local-user000001@dailyus.local`
+  - 팔로우가 많은 사용자: `local-user000011@dailyus.local`
+  - fallback 확인용 사용자: 팔로우, 그룹이 없는 사용자
+
+### 인덱스
+- 이전
+  - `idx_posts_user_id_created_at (user_id, created_at)`
+- 리팩토링 후
+  - `idx_posts_user_deleted_created_at (user_id, deleted_at, created_at, post_id)`
+
+## 4. 테스트 방식
+
+### 4.1 API 응답 시간
+
+각 사용자로 로그인 후 아래를 3회 호출
+
+- 첫 페이지: `GET /api/v1/posts?size=10`
+- 다음 페이지: 첫 페이지 응답의 `lastCreatedAt`, `lastPostId`를 사용해 재호출
+
+### 4.2 SQL 비교
+
+- 이전 `offset` SQL
+- 현재 `cursor` SQL
+- `EXPLAIN ANALYZE`
+
+## 5. API 테스트 결과
+
+### 5.1 첫 페이지 응답 시간 비교
+
+| 구분 | 계정 특성 | 이전 Offset 평균 | 현재 Cursor 평균 | 변화 |
+| --- | --- | ---: | ---: | ---: |
+| 일반 사용자 | `userId = 1` | 92.27ms | 109.74ms | +18.9% |
+| 팔로우가 많은 사용자 | `userId = 11` | 3591.97ms | 2806.01ms | -21.9% |
+| fallback 사용자 | 신규 가입 사용자 | 10094.17ms | 4842.78ms | -52.0% |
+
+### 5.2 Cursor 첫 페이지 응답 시간
+
+| 구분 | 호출 결과 | 1회차 | 평균 | 최소 | 최대 |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 일반 사용자 | 10건 반환 | 302.64ms | 109.74ms | 11.99ms | 302.64ms |
+| 팔로우가 많은 사용자 | 10건 반환 | 2712.53ms | 2806.01ms | 2712.53ms | 2900.78ms |
+| fallback 사용자 | 10건 반환 | 3247.73ms | 4842.78ms | 3234.80ms | 8045.80ms |
+
+- 일반 사용자는 이전과 큰 차이가 없다.
+- 팔로우가 많은 사용자는 첫 페이지에서도 약 `22%` 개선됐다.
+- fallback 사용자는 이전 `10초`에서 `4.8초`로 개선됐다.
+
+### 5.3 다음 페이지 응답 시간
+
+| 구분 | 현재 Cursor 평균 | 최소 | 최대 |
+| --- | ---: | ---: | ---: |
+| 일반 사용자 | 14.99ms | 11.15ms | 21.89ms |
+| 팔로우가 많은 사용자 | 2899.36ms | 2865.08ms | 2942.34ms |
+| fallback 사용자 | 6681.29ms | 3463.68ms | 8308.38ms |
+
+## 6. SQL 직접 비교 결과
+
+### 6.1 개인화 피드 (`userId = 11`)
+
+| 위치 | Offset 평균 | Cursor 평균 | 변화 |
+| --- | ---: | ---: | ---: |
+| 첫 페이지 (`offset 0`) | 2906.56ms | 2702.07ms | -7.0% |
+| 다음 페이지 (`offset 10`) | 2733.08ms | 2785.26ms | +1.9% |
+| 뒤쪽 페이지 (`offset 10,000`) | 3102.25ms | 2753.96ms | -11.2% |
+| 깊은 페이지 (`offset 100,000`) | 3080.67ms | 2645.99ms | -14.1% |
+
+- 개인화 피드는 첫 페이지/다음 페이지에서는 `offset`과 `cursor` 차이가 크지 않다.
+- 하지만 뒤로 갈수록 `cursor`가 조금씩 유리해진다.
+- 사용자 집합과 게시물 후보를 읽고 정렬하기 때문에 개선 폭이 기대보다 크지 않다.
+
+### 6.2 fallback 최근 피드
+
+| 위치 | Offset 평균 | Cursor 평균 | 변화 |
+| --- | ---: | ---: | ---: |
+| 첫 페이지 (`offset 0`) | 6447.24ms | 4783.15ms | -25.8% |
+| 다음 페이지 (`offset 10`) | 4684.75ms | 6531.14ms | +39.4% |
+| 뒤쪽 페이지 (`offset 10,000`) | 4214.72ms | 4891.90ms | +16.1% |
+| 깊은 페이지 (`offset 100,000`) | 11990.28ms | 4799.54ms | -60.0% |
+
+- 최근 피드는 측정 편차가 크다.
+- 뒤로 갈수록 `cursor`가 확실히 유리했다.
+
+## 7. 종합 결론
+
+- `cursor` 전환 이후, API 기준으로
+  - 팔로우가 많은 사용자 첫 페이지는 약 `21.9%` 개선
+  - fallback 최근 피드 첫 페이지는 약 `52.0%` 개선
+- 뒷 페이지 비교에서는 `offset` 대비 `cursor`가 유리해진다.
+  - 개인화 피드 `offset 100,000`: `3098ms -> 2746ms`
+  - 최근 피드 `offset 100,000`: `11211ms -> 3154ms`
+
+## 8. 기타
+- Offset 기반 Pagination으로 무한 스크롤 구현 시 중복된 페이지가 출력될 수 있다. 
+- 단순히 게시글 개수만으로 구분 하는 방식이기 때문에 게시글이 새롭게 추가 되는 상황을 생각해보자.  
+-> 따라서 Cursor 기반 방식으로 구현하는 것이 적합하다.

--- a/docs/10_Resource/dailyus_schema.sql
+++ b/docs/10_Resource/dailyus_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE posts (
     like_count BIGINT NOT NULL DEFAULT 0,
     user_id BIGINT NOT NULL,
     PRIMARY KEY (post_id),
-    INDEX idx_posts_user_id_created_at (user_id, created_at),
+    INDEX idx_posts_user_deleted_created_at_post_id (user_id, deleted_at, created_at, post_id),
     CONSTRAINT fk_posts_user_id
         FOREIGN KEY (user_id) REFERENCES users (user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/controller/PostController.java
@@ -10,7 +10,9 @@ import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
 import com.jaeychoi.dailyus.post.service.PostCreateService;
 import com.jaeychoi.dailyus.post.service.PostFeedService;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,9 +33,12 @@ public class PostController {
   @GetMapping
   @AuthRequired
   public ApiResponse<PostFeedResponse> getFeed(@AuthenticatedUser CurrentUser user,
-      @RequestParam(required = false, defaultValue = "0") Long page,
+      @RequestParam(required = false)
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+      LocalDateTime createdAt,
+      @RequestParam(required = false) Long postId,
       @RequestParam(required = false, defaultValue = "10") Long size) {
-    return ApiResponse.success(postFeedService.getFeed(user.userId(), page, size));
+    return ApiResponse.success(postFeedService.getFeed(user.userId(), createdAt, postId, size));
   }
 
   @PostMapping

--- a/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/dto/PostFeedResponse.java
@@ -1,10 +1,13 @@
 package com.jaeychoi.dailyus.post.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record PostFeedResponse(
     List<PostFeedItemResponse> items,
-    Long page,
+    LocalDateTime lastCreatedAt,
+    Long lastPostId,
+    boolean hasNext,
     Long size) {
 
 }

--- a/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/mapper/PostMapper.java
@@ -3,6 +3,7 @@ package com.jaeychoi.dailyus.post.mapper;
 import com.jaeychoi.dailyus.post.domain.Post;
 import com.jaeychoi.dailyus.post.dto.PostFeedRow;
 import com.jaeychoi.dailyus.post.dto.PostImageRow;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -15,9 +16,9 @@ public interface PostMapper {
 
   boolean existsFeedPosts(Long userId);
 
-  List<PostFeedRow> findFeedPosts(Long userId, Long size, Long offset);
+  List<PostFeedRow> findFeedPosts(Long userId, Long size, LocalDateTime createdAt, Long postId);
 
-  List<PostFeedRow> findRecentFeedPosts(Long size, Long offset);
+  List<PostFeedRow> findRecentFeedPosts(Long size, LocalDateTime createdAt, Long postId);
 
   List<PostImageRow> findImagesByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
+++ b/src/main/java/com/jaeychoi/dailyus/post/service/PostFeedService.java
@@ -5,6 +5,7 @@ import com.jaeychoi.dailyus.post.dto.PostFeedResponse;
 import com.jaeychoi.dailyus.post.dto.PostFeedRow;
 import com.jaeychoi.dailyus.post.dto.PostImageRow;
 import com.jaeychoi.dailyus.post.mapper.PostMapper;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,16 +18,57 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PostFeedService {
 
+  private static final long DEFAULT_SIZE = 10L;
+
   private final PostMapper postMapper;
 
-  public PostFeedResponse getFeed(Long userId, Long page, Long size) {
-    Long pageValue = page == null ? 0L : page;
-    Long sizeValue = size == null ? 10L : size;
+  public PostFeedResponse getFeed(Long userId, LocalDateTime createdAt, Long postId, Long size) {
+    long pageSize = resolvePageSize(size);
+    List<PostFeedRow> rows = loadFeedRows(userId, createdAt, postId, pageSize + 1);
+    boolean hasNext = hasNext(rows, pageSize);
+    List<PostFeedRow> pageRows = getPageRows(rows, pageSize, hasNext);
+    Map<Long, List<String>> imageUrlsByPostId = loadImageUrlsByPostId(pageRows);
+    PostFeedRow lastRow = hasNext ? getLastRow(pageRows) : null;
 
-    List<PostFeedRow> rows = loadFeedPosts(userId, pageValue, sizeValue);
-    Map<Long, List<String>> imageUrlsByPostId = loadImageUrlsByPostId(rows);
+    return new PostFeedResponse(
+        toItems(pageRows, imageUrlsByPostId),
+        lastRow == null ? null : lastRow.createdAt(),
+        lastRow == null ? null : lastRow.postId(),
+        hasNext,
+        pageSize
+    );
+  }
 
-    List<PostFeedItemResponse> items = rows.stream()
+  private long resolvePageSize(Long size) {
+    return size == null ? DEFAULT_SIZE : size;
+  }
+
+  private List<PostFeedRow> loadFeedRows(
+      Long userId,
+      LocalDateTime createdAt,
+      Long postId,
+      long size
+  ) {
+    if (postMapper.existsFeedPosts(userId)) {
+      return postMapper.findFeedPosts(userId, size, createdAt, postId);
+    }
+
+    return postMapper.findRecentFeedPosts(size, createdAt, postId);
+  }
+
+  private boolean hasNext(List<PostFeedRow> rows, long pageSize) {
+    return rows.size() > pageSize;
+  }
+
+  private List<PostFeedRow> getPageRows(List<PostFeedRow> rows, long pageSize, boolean hasNext) {
+    return hasNext ? rows.subList(0, (int) pageSize) : rows;
+  }
+
+  private List<PostFeedItemResponse> toItems(
+      List<PostFeedRow> rows,
+      Map<Long, List<String>> imageUrlsByPostId
+  ) {
+    return rows.stream()
         .map(row -> new PostFeedItemResponse(
             row.postId(),
             row.userId(),
@@ -38,19 +80,10 @@ public class PostFeedService {
             row.createdAt()
         ))
         .toList();
-
-    return new PostFeedResponse(items, pageValue, sizeValue);
-
   }
 
-  private List<PostFeedRow> loadFeedPosts(Long userId, Long page, Long size) {
-    Long offset = page * size;
-
-    if (postMapper.existsFeedPosts(userId)) {
-      return postMapper.findFeedPosts(userId, size, offset);
-    }
-
-    return postMapper.findRecentFeedPosts(size, offset);
+  private PostFeedRow getLastRow(List<PostFeedRow> rows) {
+    return rows.get(rows.size() - 1);
   }
 
   private Map<Long, List<String>> loadImageUrlsByPostId(List<PostFeedRow> rows) {

--- a/src/main/resources/mapper/post/PostMapper.xml
+++ b/src/main/resources/mapper/post/PostMapper.xml
@@ -71,8 +71,11 @@
         JOIN posts p ON p.user_id = u.user_id
         WHERE u.deleted_at IS NULL
         AND p.deleted_at IS NULL
+        <if test="createdAt != null and postId != null">
+          AND (p.created_at, p.post_id) &lt; (#{createdAt}, #{postId})
+        </if>
         ORDER BY p.created_at DESC, p.post_id DESC
-          LIMIT #{size} OFFSET #{offset}
+        LIMIT #{size}
     </select>
     
     <select id="findRecentFeedPosts" resultMap="postFeedRowResultMap">
@@ -87,8 +90,11 @@
         JOIN users u ON u.user_id = p.user_id
         WHERE p.deleted_at IS NULL
         AND u.deleted_at IS NULL
+        <if test="createdAt != null and postId != null">
+            AND (p.created_at, p.post_id) &lt; (#{createdAt}, #{postId})
+        </if>
         ORDER BY p.created_at DESC, p.post_id DESC
-        LIMIT #{size} OFFSET #{offset}
+        LIMIT #{size}
     </select>
 
     <select id="findImagesByPostIds" resultMap="postImageRowResultMap">

--- a/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/controller/PostControllerTest.java
@@ -63,7 +63,7 @@ class PostControllerTest {
   void createPostReturnsCreatedResponse() throws Exception {
     PostCreateRequest request = new PostCreateRequest(
         List.of("https://cdn.example.com/1.png"),
-        "미라클 모닝 #Morning"
+        "sample content #Morning"
     );
     PostCreateResponse response = new PostCreateResponse(
         10L,
@@ -90,7 +90,7 @@ class PostControllerTest {
 
   @Test
   void createPostReturnsBadRequestWhenImagesAreEmpty() throws Exception {
-    PostCreateRequest request = new PostCreateRequest(List.of(), "매일 매일");
+    PostCreateRequest request = new PostCreateRequest(List.of(), "sample content");
 
     mockMvc.perform(post("/api/v1/posts")
             .requestAttr(AuthRequestAttributes.CURRENT_USER,
@@ -114,20 +114,53 @@ class PostControllerTest {
             3L,
             LocalDateTime.of(2026, 4, 6, 10, 0)
         )),
-        0L,
+        LocalDateTime.of(2026, 4, 6, 10, 0),
+        10L,
+        true,
         10L
     );
-    when(postFeedService.getFeed(1L, 0L, 10L)).thenReturn(response);
+    when(postFeedService.getFeed(1L, null, null, 10L)).thenReturn(response);
 
     mockMvc.perform(get("/api/v1/posts")
             .requestAttr(AuthRequestAttributes.CURRENT_USER,
                 new CurrentUser(1L, "user@example.com", "user")))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.code").value("OK"))
-        .andExpect(jsonPath("$.data.page").value(0L))
+        .andExpect(jsonPath("$.data.lastCreatedAt").value("2026-04-06T10:00:00"))
+        .andExpect(jsonPath("$.data.lastPostId").value(10L))
+        .andExpect(jsonPath("$.data.hasNext").value(true))
         .andExpect(jsonPath("$.data.size").value(10L))
         .andExpect(jsonPath("$.data.items[0].postId").value(10L))
         .andExpect(jsonPath("$.data.items[0].imageUrls[0]").value("https://cdn.example.com/1.png"));
+  }
+
+  @Test
+  void getFeedPassesCursorAndSizeQueryParameters() throws Exception {
+    PostFeedResponse response = new PostFeedResponse(
+        List.of(),
+        LocalDateTime.of(2026, 4, 6, 8, 0),
+        7L,
+        true,
+        5L
+    );
+    when(postFeedService.getFeed(
+        1L,
+        LocalDateTime.of(2026, 4, 6, 9, 0),
+        15L,
+        5L
+    )).thenReturn(response);
+
+    mockMvc.perform(get("/api/v1/posts")
+            .queryParam("createdAt", "2026-04-06T09:00:00")
+            .queryParam("postId", "15")
+            .queryParam("size", "5")
+            .requestAttr(AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(1L, "user@example.com", "user")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.lastCreatedAt").value("2026-04-06T08:00:00"))
+        .andExpect(jsonPath("$.data.lastPostId").value(7L))
+        .andExpect(jsonPath("$.data.hasNext").value(true))
+        .andExpect(jsonPath("$.data.size").value(5L));
   }
 
   @Test

--- a/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/mapper/PostMapperTest.java
@@ -2,9 +2,9 @@ package com.jaeychoi.dailyus.post.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jaeychoi.dailyus.post.domain.Post;
 import com.jaeychoi.dailyus.post.dto.PostFeedRow;
 import com.jaeychoi.dailyus.post.dto.PostImageRow;
-import com.jaeychoi.dailyus.post.domain.Post;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,24 +30,20 @@ class PostMapperTest {
 
   @Test
   void insertPersistsPostAndSetsGeneratedKey() throws Exception {
-    // given
     Long userId = insertUser("author@example.com", "author");
     Post post = Post.builder()
         .userId(userId)
         .content("today's routine")
         .build();
 
-    // when
     postMapper.insert(post);
 
-    // then
     assertThat(post.getPostId()).isNotNull();
     assertThat(countPosts(post.getPostId())).isEqualTo(1);
   }
 
   @Test
   void insertImagesPersistsAllPostImages() throws Exception {
-    // given
     Long userId = insertUser("images@example.com", "images");
     Long postId = insertPost(userId, "post with images");
     List<String> imageUrls = List.of(
@@ -55,10 +51,8 @@ class PostMapperTest {
         "https://cdn.example.com/2.png"
     );
 
-    // when
     postMapper.insertImages(postId, imageUrls);
 
-    // then
     assertThat(countPostImages(postId)).isEqualTo(2);
     assertThat(loadPostImageUrls(postId))
         .containsExactlyInAnyOrderElementsOf(imageUrls);
@@ -66,7 +60,6 @@ class PostMapperTest {
 
   @Test
   void findFeedPostsReturnsPostsFromFolloweesAndGroupMembers() throws Exception {
-    // given
     Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
     Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
     Long groupMemberId = insertUser(uniqueEmail("group-member"), uniqueNickname("group-member"));
@@ -77,14 +70,14 @@ class PostMapperTest {
     insertGroupMember(groupId, groupMemberId);
     Long followeePostId = insertPost(followeeId, "followee post");
     Long groupMemberPostId = insertPost(groupMemberId, "group member post");
+    updatePostCreatedAt(followeePostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+    updatePostCreatedAt(groupMemberPostId, LocalDateTime.of(2026, 4, 6, 8, 0));
     insertPost(outsiderId, "outsider post");
 
-    // when
-    List<PostFeedRow> rows = postMapper.findFeedPosts(loginUserId, 10L, 0L);
+    List<PostFeedRow> rows = postMapper.findFeedPosts(loginUserId, 10L, null, null);
 
-    // then
     assertThat(rows).extracting(PostFeedRow::postId)
-        .contains(followeePostId, groupMemberPostId)
+        .containsSequence(followeePostId, groupMemberPostId)
         .doesNotContainNull();
     assertThat(rows).extracting(PostFeedRow::userId)
         .contains(followeeId, groupMemberId)
@@ -92,55 +85,111 @@ class PostMapperTest {
   }
 
   @Test
+  void findFeedPostsReturnsRowsAfterCompositeCursor() throws Exception {
+    Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
+    Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
+    insertFollow(loginUserId, followeeId);
+    Long olderPostId = insertPost(followeeId, "older post");
+    Long cursorPostId = insertPost(followeeId, "cursor post");
+    Long newerPostId = insertPost(followeeId, "newer post");
+    updatePostCreatedAt(olderPostId, LocalDateTime.of(2026, 4, 6, 8, 0));
+    updatePostCreatedAt(cursorPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+    updatePostCreatedAt(newerPostId, LocalDateTime.of(2026, 4, 6, 10, 0));
+
+    List<PostFeedRow> rows = postMapper.findFeedPosts(
+        loginUserId,
+        10L,
+        LocalDateTime.of(2026, 4, 6, 9, 0),
+        cursorPostId
+    );
+
+    assertThat(rows).extracting(PostFeedRow::postId)
+        .contains(olderPostId)
+        .doesNotContain(cursorPostId, newerPostId);
+  }
+
+  @Test
+  void findFeedPostsUsesPostIdAsTieBreakerWithinSameCreatedAt() throws Exception {
+    Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
+    Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
+    insertFollow(loginUserId, followeeId);
+    Long lowerPostId = insertPost(followeeId, "lower post");
+    Long higherPostId = insertPost(followeeId, "higher post");
+    LocalDateTime sameCreatedAt = LocalDateTime.of(2026, 4, 6, 9, 0);
+    updatePostCreatedAt(lowerPostId, sameCreatedAt);
+    updatePostCreatedAt(higherPostId, sameCreatedAt);
+
+    List<PostFeedRow> rows = postMapper.findFeedPosts(loginUserId, 10L, sameCreatedAt, higherPostId);
+
+    assertThat(rows).extracting(PostFeedRow::postId)
+        .contains(lowerPostId)
+        .doesNotContain(higherPostId);
+  }
+
+  @Test
   void existsFeedPostsReturnsTrueWhenRelatedUsersHavePosts() throws Exception {
-    // given
     Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
     Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
     insertFollow(loginUserId, followeeId);
     insertPost(followeeId, "followee post");
 
-    // when
     boolean exists = postMapper.existsFeedPosts(loginUserId);
 
-    // then
     assertThat(exists).isTrue();
   }
 
   @Test
   void existsFeedPostsReturnsFalseWhenRelatedUsersHaveNoPosts() throws Exception {
-    // given
     Long loginUserId = insertUser(uniqueEmail("login"), uniqueNickname("login"));
     Long followeeId = insertUser(uniqueEmail("followee"), uniqueNickname("followee"));
     insertFollow(loginUserId, followeeId);
 
-    // when
     boolean exists = postMapper.existsFeedPosts(loginUserId);
 
-    // then
     assertThat(exists).isFalse();
   }
 
   @Test
-  void findRecentFeedPostsReturnsRecentPostsOrderedByCreatedAtDesc() throws Exception {
-    // given
+  void findRecentFeedPostsReturnsRecentPostsOrderedByCreatedAtDescThenPostIdDesc() throws Exception {
     Long firstUserId = insertUser(uniqueEmail("first"), uniqueNickname("first"));
     Long secondUserId = insertUser(uniqueEmail("second"), uniqueNickname("second"));
     Long olderPostId = insertPost(firstUserId, "older post");
-    Long newerPostId = insertPost(secondUserId, "newer post");
+    Long sameTimeLowerPostId = insertPost(firstUserId, "same-time lower");
+    Long sameTimeHigherPostId = insertPost(secondUserId, "same-time higher");
     updatePostCreatedAt(olderPostId, LocalDateTime.of(2026, 4, 6, 8, 0));
-    updatePostCreatedAt(newerPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+    updatePostCreatedAt(sameTimeLowerPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+    updatePostCreatedAt(sameTimeHigherPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
 
-    // when
-    List<PostFeedRow> rows = postMapper.findRecentFeedPosts(10L, 0L);
+    List<PostFeedRow> rows = postMapper.findRecentFeedPosts(10L, null, null);
 
-    // then
     assertThat(rows).extracting(PostFeedRow::postId)
-        .containsSequence(newerPostId, olderPostId);
+        .containsSequence(sameTimeHigherPostId, sameTimeLowerPostId, olderPostId);
+  }
+
+  @Test
+  void findRecentFeedPostsReturnsRowsAfterCompositeCursor() throws Exception {
+    Long firstUserId = insertUser(uniqueEmail("first"), uniqueNickname("first"));
+    Long secondUserId = insertUser(uniqueEmail("second"), uniqueNickname("second"));
+    Long olderPostId = insertPost(secondUserId, "older post");
+    Long cursorPostId = insertPost(firstUserId, "cursor post");
+    Long newerPostId = insertPost(firstUserId, "newer post");
+    updatePostCreatedAt(olderPostId, LocalDateTime.of(2026, 4, 6, 8, 0));
+    updatePostCreatedAt(cursorPostId, LocalDateTime.of(2026, 4, 6, 9, 0));
+    updatePostCreatedAt(newerPostId, LocalDateTime.of(2026, 4, 6, 10, 0));
+
+    List<PostFeedRow> rows = postMapper.findRecentFeedPosts(
+        10L,
+        LocalDateTime.of(2026, 4, 6, 9, 0),
+        cursorPostId
+    );
+
+    assertThat(rows).extracting(PostFeedRow::postId)
+        .contains(olderPostId)
+        .doesNotContain(cursorPostId, newerPostId);
   }
 
   @Test
   void findImagesByPostIdsReturnsImagesGroupedInCreatedOrder() throws Exception {
-    // given
     Long userId = insertUser(uniqueEmail("author"), uniqueNickname("author"));
     Long firstPostId = insertPost(userId, "first post");
     Long secondPostId = insertPost(userId, "second post");
@@ -150,10 +199,8 @@ class PostMapperTest {
     ));
     postMapper.insertImages(secondPostId, List.of("https://cdn.example.com/second-1.png"));
 
-    // when
     List<PostImageRow> rows = postMapper.findImagesByPostIds(List.of(firstPostId, secondPostId));
 
-    // then
     assertThat(rows).extracting(PostImageRow::postId)
         .containsExactly(firstPostId, firstPostId, secondPostId);
     assertThat(rows).extracting(PostImageRow::imageUrl)

--- a/src/test/java/com/jaeychoi/dailyus/post/service/PostFeedServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/post/service/PostFeedServiceTest.java
@@ -28,8 +28,7 @@ class PostFeedServiceTest {
   private PostFeedService postFeedService;
 
   @Test
-  void getFeedReturnsPersonalizedFeedWithImages() {
-    // given
+  void getFeedReturnsPersonalizedFeedWithCompositeCursor() {
     Long userId = 1L;
     PostFeedRow firstRow = new PostFeedRow(
         10L,
@@ -49,21 +48,32 @@ class PostFeedServiceTest {
         1L,
         LocalDateTime.of(2026, 4, 6, 9, 0)
     );
+    PostFeedRow thirdRow = new PostFeedRow(
+        8L,
+        4L,
+        "author-3",
+        "https://example.com/profile-3.png",
+        "content-3",
+        0L,
+        LocalDateTime.of(2026, 4, 6, 8, 0)
+    );
+
     when(postMapper.existsFeedPosts(userId)).thenReturn(true);
-    when(postMapper.findFeedPosts(userId, 10L, 0L)).thenReturn(List.of(firstRow, secondRow));
+    when(postMapper.findFeedPosts(userId, 3L, null, null))
+        .thenReturn(List.of(firstRow, secondRow, thirdRow));
     when(postMapper.findImagesByPostIds(List.of(10L, 9L))).thenReturn(List.of(
         new PostImageRow(10L, "https://cdn.example.com/10-1.png"),
         new PostImageRow(10L, "https://cdn.example.com/10-2.png"),
         new PostImageRow(9L, "https://cdn.example.com/9-1.png")
     ));
 
-    // when
-    PostFeedResponse response = postFeedService.getFeed(userId, 0L, 10L);
+    PostFeedResponse response = postFeedService.getFeed(userId, null, null, 2L);
 
-    // then
-    verify(postMapper, never()).findRecentFeedPosts(10L, 0L);
-    assertThat(response.page()).isEqualTo(0L);
-    assertThat(response.size()).isEqualTo(10L);
+    verify(postMapper, never()).findRecentFeedPosts(3L, null, null);
+    assertThat(response.lastCreatedAt()).isEqualTo(LocalDateTime.of(2026, 4, 6, 9, 0));
+    assertThat(response.lastPostId()).isEqualTo(9L);
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.size()).isEqualTo(2L);
     assertThat(response.items()).hasSize(2);
     assertThat(response.items().get(0).postId()).isEqualTo(10L);
     assertThat(response.items().get(0).imageUrls())
@@ -74,9 +84,9 @@ class PostFeedServiceTest {
   }
 
   @Test
-  void getFeedReturnsRecentPostsWhenFeedPostsDoNotExist() {
-    // given
+  void getFeedPassesCompositeCursorToRecentFeedQuery() {
     Long userId = 1L;
+    LocalDateTime cursorCreatedAt = LocalDateTime.of(2026, 4, 6, 9, 0);
     PostFeedRow recentRow = new PostFeedRow(
         8L,
         4L,
@@ -86,34 +96,37 @@ class PostFeedServiceTest {
         0L,
         LocalDateTime.of(2026, 4, 6, 8, 0)
     );
+
     when(postMapper.existsFeedPosts(userId)).thenReturn(false);
-    when(postMapper.findRecentFeedPosts(10L, 0L)).thenReturn(List.of(recentRow));
+    when(postMapper.findRecentFeedPosts(11L, cursorCreatedAt, 15L)).thenReturn(List.of(recentRow));
     when(postMapper.findImagesByPostIds(List.of(8L))).thenReturn(List.of());
 
-    // when
-    PostFeedResponse response = postFeedService.getFeed(userId, 0L, 10L);
+    PostFeedResponse response = postFeedService.getFeed(userId, cursorCreatedAt, 15L, 10L);
 
-    // then
-    verify(postMapper).findRecentFeedPosts(10L, 0L);
+    verify(postMapper).findRecentFeedPosts(11L, cursorCreatedAt, 15L);
     assertThat(response.items()).hasSize(1);
     assertThat(response.items().get(0).postId()).isEqualTo(8L);
+    assertThat(response.lastCreatedAt()).isNull();
+    assertThat(response.lastPostId()).isNull();
+    assertThat(response.hasNext()).isFalse();
   }
 
   @Test
-  void getFeedReturnsEmptyItemsWhenFeedPostsExistButRequestedPageHasNoRows() {
-    // given
+  void getFeedReturnsEmptyItemsWhenCursorHasNoRows() {
     Long userId = 1L;
+    LocalDateTime cursorCreatedAt = LocalDateTime.of(2026, 4, 6, 9, 0);
+
     when(postMapper.existsFeedPosts(userId)).thenReturn(true);
-    when(postMapper.findFeedPosts(userId, 10L, 10L)).thenReturn(List.of());
+    when(postMapper.findFeedPosts(userId, 11L, cursorCreatedAt, 9L)).thenReturn(List.of());
 
-    // when
-    PostFeedResponse response = postFeedService.getFeed(userId, 1L, 10L);
+    PostFeedResponse response = postFeedService.getFeed(userId, cursorCreatedAt, 9L, 10L);
 
-    // then
-    verify(postMapper, never()).findRecentFeedPosts(10L, 10L);
+    verify(postMapper, never()).findRecentFeedPosts(11L, cursorCreatedAt, 9L);
     verify(postMapper, never()).findImagesByPostIds(anyList());
     assertThat(response.items()).isEmpty();
-    assertThat(response.page()).isEqualTo(1L);
     assertThat(response.size()).isEqualTo(10L);
+    assertThat(response.lastCreatedAt()).isNull();
+    assertThat(response.lastPostId()).isNull();
+    assertThat(response.hasNext()).isFalse();
   }
 }


### PR DESCRIPTION
## ✨ 작업 내용                                                                                                                                                                                                                    
- 피드 조회 API의 `cursor` 기반 성능을 기존 `offset` 방식과 비교하는 테스트 수행
- `offset` 대비 `cursor`의 차이 분석

##  관련 이슈
- closes #72 
                                                                                                                                                                                                                                    
##  스크린샷 / 참고 자료
- `docs/03_Test/피드_조회_API_테스트_02/피드_조회_API_성능테스트_싱글.md`