### PR TITLE
[Feat] 그룹 랭킹 기능 구현

### DIFF
--- a/src/main/java/com/jaeychoi/dailyus/group/controller/GroupController.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/controller/GroupController.java
@@ -7,11 +7,14 @@ import com.jaeychoi.dailyus.common.web.ApiResponse;
 import com.jaeychoi.dailyus.group.dto.GroupCreateRequest;
 import com.jaeychoi.dailyus.group.dto.GroupCreateResponse;
 import com.jaeychoi.dailyus.group.dto.GroupJoinResponse;
+import com.jaeychoi.dailyus.group.dto.GroupRankResponse;
 import com.jaeychoi.dailyus.group.service.GroupCreateService;
 import com.jaeychoi.dailyus.group.service.GroupJoinService;
+import com.jaeychoi.dailyus.group.service.GroupRankService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +29,7 @@ public class GroupController {
 
   private final GroupCreateService groupCreateService;
   private final GroupJoinService groupJoinService;
+  private final GroupRankService groupRankService;
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
@@ -45,4 +49,10 @@ public class GroupController {
     return ApiResponse.success(response);
   }
 
+  @GetMapping("/{groupId}/rank")
+  @AuthRequired
+  public ApiResponse<GroupRankResponse> getRank(@PathVariable Long groupId, @AuthenticatedUser CurrentUser user) {
+    GroupRankResponse response = groupRankService.getRank(groupId, user.userId());
+    return ApiResponse.success(response);
+  }
 }

--- a/src/main/java/com/jaeychoi/dailyus/group/dto/GroupMemberRankRow.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/dto/GroupMemberRankRow.java
@@ -1,7 +1,7 @@
 package com.jaeychoi.dailyus.group.dto;
 
 public record GroupMemberRankRow(
-    Integer rank,
+    Integer ranking,
     Long userId,
     String nickname,
     String profileImage,

--- a/src/main/java/com/jaeychoi/dailyus/group/dto/GroupMemberRankRow.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/dto/GroupMemberRankRow.java
@@ -1,0 +1,11 @@
+package com.jaeychoi.dailyus.group.dto;
+
+public record GroupMemberRankRow(
+    Integer rank,
+    Long userId,
+    String nickname,
+    String profileImage,
+    Long postCount
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/group/dto/GroupRankResponse.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/dto/GroupRankResponse.java
@@ -1,0 +1,10 @@
+package com.jaeychoi.dailyus.group.dto;
+
+import java.util.List;
+
+public record GroupRankResponse(
+    Long groupId,
+    List<GroupMemberRankRow> rank
+) {
+
+}

--- a/src/main/java/com/jaeychoi/dailyus/group/mapper/GroupMapper.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/mapper/GroupMapper.java
@@ -1,6 +1,8 @@
 package com.jaeychoi.dailyus.group.mapper;
 
 import com.jaeychoi.dailyus.group.domain.Group;
+import com.jaeychoi.dailyus.group.dto.GroupMemberRankRow;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -18,6 +20,9 @@ public interface GroupMapper {
   boolean existsMemberByIdAndMemberId(Long groupId, Long userId);
 
   int countJoinedGroupsByMemberId(Long userId);
+
+  List<GroupMemberRankRow> findMemberRanks(Long groupId, LocalDateTime startAt,
+      LocalDateTime endAt);
 
   List<Long> findMembersByMemberId(Long memberId);
 }

--- a/src/main/java/com/jaeychoi/dailyus/group/service/GroupRankService.java
+++ b/src/main/java/com/jaeychoi/dailyus/group/service/GroupRankService.java
@@ -1,0 +1,40 @@
+package com.jaeychoi.dailyus.group.service;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.group.domain.Group;
+import com.jaeychoi.dailyus.group.dto.GroupMemberRankRow;
+import com.jaeychoi.dailyus.group.dto.GroupRankResponse;
+import com.jaeychoi.dailyus.group.mapper.GroupMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupRankService {
+
+  private final GroupMapper groupMapper;
+
+  public GroupRankResponse getRank(Long groupId, Long userId) {
+    Group group = groupMapper.findActiveById(groupId);
+    if (group == null) {
+      throw new BaseException(ErrorCode.GROUP_NOT_FOUND);
+    }
+    validateMember(groupId, userId);
+
+    LocalDateTime startAt = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+    LocalDateTime endAt = startAt.plusMonths(1);
+    List<GroupMemberRankRow> rankRows = groupMapper.findMemberRanks(groupId, startAt, endAt);
+
+    return new GroupRankResponse(groupId, rankRows);
+  }
+
+  private void validateMember(Long groupId, Long userId) {
+    if (!groupMapper.existsMemberByIdAndMemberId(groupId, userId)) {
+      throw new BaseException(ErrorCode.FORBIDDEN);
+    }
+  }
+}

--- a/src/main/resources/mapper/group/GroupMapper.xml
+++ b/src/main/resources/mapper/group/GroupMapper.xml
@@ -16,6 +16,17 @@
     <result property="deletedAt" column="deleted_at"/>
   </resultMap>
 
+  <resultMap id="groupMemberRankRowResultMap"
+    type="com.jaeychoi.dailyus.group.dto.GroupMemberRankRow">
+    <constructor>
+      <arg column="rank" javaType="int"/>
+      <arg column="user_id" javaType="java.lang.Long"/>
+      <arg column="nickname" javaType="java.lang.String"/>
+      <arg column="profile_image" javaType="java.lang.String"/>
+      <arg column="post_count" javaType="java.lang.Long"/>
+    </constructor>
+  </resultMap>
+
   <insert id="insert"
     parameterType="com.jaeychoi.dailyus.group.domain.Group"
     useGeneratedKeys="true"
@@ -75,6 +86,26 @@
     SELECT COUNT(*)
     FROM group_members
     WHERE user_id = #{userId}
+  </select>
+
+  <select id="findMemberRanks" resultMap="groupMemberRankRowResultMap">
+    SELECT DENSE_RANK() OVER (ORDER BY ranked.post_count DESC) AS rank, ranked.user_id,
+           ranked.nickname,
+           ranked.profile_image,
+           ranked.post_count
+    FROM (SELECT gm.user_id,
+                 u.nickname,
+                 u.profile_image,
+                 COUNT(p.post_id) AS post_count
+          FROM group_members gm
+                 JOIN users u ON u.user_id = gm.user_id
+                 LEFT JOIN posts p ON p.user_id = gm.user_id
+            AND p.deleted_at IS NULL
+            AND p.created_at &gt;= #{startAt}
+            AND p.created_at &lt; #{endAt}
+          WHERE gm.group_id = #{groupId}
+            AND u.deleted_at IS NULL
+          GROUP BY gm.user_id, u.nickname, u.profile_image) ranked
   </select>
 
   <select id="findMembersByMemberId" parameterType="long" resultType="long">

--- a/src/main/resources/mapper/group/GroupMapper.xml
+++ b/src/main/resources/mapper/group/GroupMapper.xml
@@ -19,7 +19,7 @@
   <resultMap id="groupMemberRankRowResultMap"
     type="com.jaeychoi.dailyus.group.dto.GroupMemberRankRow">
     <constructor>
-      <arg column="rank" javaType="int"/>
+      <arg column="ranking" javaType="java.lang.Integer"/>
       <arg column="user_id" javaType="java.lang.Long"/>
       <arg column="nickname" javaType="java.lang.String"/>
       <arg column="profile_image" javaType="java.lang.String"/>
@@ -89,7 +89,8 @@
   </select>
 
   <select id="findMemberRanks" resultMap="groupMemberRankRowResultMap">
-    SELECT DENSE_RANK() OVER (ORDER BY ranked.post_count DESC) AS rank, ranked.user_id,
+    SELECT DENSE_RANK() OVER (ORDER BY ranked.post_count DESC) AS ranking,
+           ranked.user_id,
            ranked.nickname,
            ranked.profile_image,
            ranked.post_count
@@ -105,7 +106,7 @@
             AND p.created_at &lt; #{endAt}
           WHERE gm.group_id = #{groupId}
             AND u.deleted_at IS NULL
-          GROUP BY gm.user_id, u.nickname, u.profile_image) ranked
+          GROUP BY gm.user_id) ranked
   </select>
 
   <select id="findMembersByMemberId" parameterType="long" resultType="long">

--- a/src/test/java/com/jaeychoi/dailyus/group/controller/GroupControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/group/controller/GroupControllerTest.java
@@ -3,6 +3,7 @@ package com.jaeychoi.dailyus.group.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,8 +17,11 @@ import com.jaeychoi.dailyus.common.web.AuthenticatedUserArgumentResolver;
 import com.jaeychoi.dailyus.group.dto.GroupCreateRequest;
 import com.jaeychoi.dailyus.group.dto.GroupCreateResponse;
 import com.jaeychoi.dailyus.group.dto.GroupJoinResponse;
+import com.jaeychoi.dailyus.group.dto.GroupMemberRankRow;
+import com.jaeychoi.dailyus.group.dto.GroupRankResponse;
 import com.jaeychoi.dailyus.group.service.GroupCreateService;
 import com.jaeychoi.dailyus.group.service.GroupJoinService;
+import com.jaeychoi.dailyus.group.service.GroupRankService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +43,9 @@ class GroupControllerTest {
   @Mock
   private GroupJoinService groupJoinService;
 
+  @Mock
+  private GroupRankService groupRankService;
+
   private MockMvc mockMvc;
 
   private ObjectMapper objectMapper;
@@ -50,7 +57,7 @@ class GroupControllerTest {
 
     objectMapper = new ObjectMapper();
     mockMvc = MockMvcBuilders.standaloneSetup(
-            new GroupController(groupCreateService, groupJoinService))
+            new GroupController(groupCreateService, groupJoinService, groupRankService))
         .setControllerAdvice(new GlobalExceptionHandler())
         .setCustomArgumentResolvers(new AuthenticatedUserArgumentResolver())
         .setValidator(validator)
@@ -181,4 +188,37 @@ class GroupControllerTest {
         .andExpect(jsonPath("$.message").value(ErrorCode.GROUP_ALREADY_JOINED.getMessage()))
         .andExpect(jsonPath("$.data").doesNotExist());
   }
+
+  @Test
+  void getRankReturnsOkResponse() throws Exception {
+    GroupRankResponse response = new GroupRankResponse(
+        1L,
+        java.util.List.of(
+            new GroupMemberRankRow(1, 2L, "tester", "https://example.com/tester.png", 3L)
+        )
+    );
+    when(groupRankService.getRank(1L, 2L)).thenReturn(response);
+
+    mockMvc.perform(get("/api/v1/groups/1/rank")
+            .requestAttr(
+                AuthRequestAttributes.CURRENT_USER,
+                new CurrentUser(2L, "tester@example.com", "tester")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("OK"))
+        .andExpect(jsonPath("$.data.groupId").value(1L))
+        .andExpect(jsonPath("$.data.rank[0].rank").value(1))
+        .andExpect(jsonPath("$.data.rank[0].userId").value(2L))
+        .andExpect(jsonPath("$.data.rank[0].nickname").value("tester"))
+        .andExpect(jsonPath("$.data.rank[0].postCount").value(3L));
+  }
+
+  @Test
+  void getRankReturnsUnauthorizedWhenCurrentUserMissing() throws Exception {
+    mockMvc.perform(get("/api/v1/groups/1/rank"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorCode.UNAUTHORIZED.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.UNAUTHORIZED.getMessage()))
+        .andExpect(jsonPath("$.data").doesNotExist());
+  }
+
 }

--- a/src/test/java/com/jaeychoi/dailyus/group/controller/GroupControllerTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/group/controller/GroupControllerTest.java
@@ -206,7 +206,7 @@ class GroupControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.code").value("OK"))
         .andExpect(jsonPath("$.data.groupId").value(1L))
-        .andExpect(jsonPath("$.data.rank[0].rank").value(1))
+        .andExpect(jsonPath("$.data.rank[0].ranking").value(1))
         .andExpect(jsonPath("$.data.rank[0].userId").value(2L))
         .andExpect(jsonPath("$.data.rank[0].nickname").value("tester"))
         .andExpect(jsonPath("$.data.rank[0].postCount").value(3L));

--- a/src/test/java/com/jaeychoi/dailyus/group/mapper/GroupMapperTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/group/mapper/GroupMapperTest.java
@@ -3,6 +3,9 @@ package com.jaeychoi.dailyus.group.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jaeychoi.dailyus.group.domain.Group;
+import com.jaeychoi.dailyus.group.dto.GroupMemberRankRow;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -156,6 +159,38 @@ class GroupMapperTest {
   }
 
   @Test
+  void findMemberRanksReturnsMonthlyPostCountsInDescendingOrder() {
+    Long ownerId = insertUser(uniqueEmail("owner"), uniqueNickname("owner"));
+    Long memberId = insertUser(uniqueEmail("member"), uniqueNickname("member"));
+    Group group = Group.builder()
+        .name("daily-us")
+        .intro("group intro")
+        .groupImage("https://example.com/group.png")
+        .ownerId(ownerId)
+        .build();
+    groupMapper.insert(group);
+    groupMapper.insertMember(group.getGroupId(), ownerId);
+    groupMapper.insertMember(group.getGroupId(), memberId);
+
+    insertPost(ownerId, LocalDateTime.of(2026, 4, 1, 10, 0));
+    insertPost(ownerId, LocalDateTime.of(2026, 4, 10, 10, 0));
+    insertPost(memberId, LocalDateTime.of(2026, 4, 3, 10, 0));
+    insertPost(memberId, LocalDateTime.of(2026, 3, 31, 23, 59));
+
+    List<GroupMemberRankRow> result = groupMapper.findMemberRanks(
+        group.getGroupId(),
+        LocalDateTime.of(2026, 4, 1, 0, 0),
+        LocalDateTime.of(2026, 5, 1, 0, 0)
+    );
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).userId()).isEqualTo(ownerId);
+    assertThat(result.get(0).postCount()).isEqualTo(2L);
+    assertThat(result.get(1).userId()).isEqualTo(memberId);
+    assertThat(result.get(1).postCount()).isEqualTo(1L);
+  }
+
+  @Test
   void findMembersByMemberIdReturnsMembersInJoinedGroups() {
     Long ownerId = insertUser(uniqueEmail("owner"), uniqueNickname("owner"));
     Long memberId = insertUser(uniqueEmail("member"), uniqueNickname("member"));
@@ -288,6 +323,27 @@ class GroupMapperTest {
     );
     assertThat(count).isNotNull();
     return count;
+  }
+
+  private void insertPost(Long userId, LocalDateTime createdAt) {
+    jdbcTemplate.update(
+        """
+            INSERT INTO posts (
+                content,
+                created_at,
+                updated_at,
+                deleted_at,
+                like_count,
+                user_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+        "content",
+        createdAt,
+        createdAt,
+        null,
+        0L,
+        userId
+    );
   }
 
   private void softDeleteUser(Long userId) {

--- a/src/test/java/com/jaeychoi/dailyus/group/service/GroupRankServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/group/service/GroupRankServiceTest.java
@@ -1,0 +1,88 @@
+package com.jaeychoi.dailyus.group.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jaeychoi.dailyus.common.exception.BaseException;
+import com.jaeychoi.dailyus.common.exception.ErrorCode;
+import com.jaeychoi.dailyus.group.domain.Group;
+import com.jaeychoi.dailyus.group.dto.GroupMemberRankRow;
+import com.jaeychoi.dailyus.group.dto.GroupRankResponse;
+import com.jaeychoi.dailyus.group.mapper.GroupMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroupRankServiceTest {
+
+  @Mock
+  private GroupMapper groupMapper;
+
+  @InjectMocks
+  private GroupRankService groupRankService;
+
+  @Test
+  void getRankReturnsMonthlyPostRanking() {
+    Long groupId = 10L;
+    Long userId = 2L;
+    when(groupMapper.findActiveById(groupId)).thenReturn(Group.builder().groupId(groupId).build());
+    when(groupMapper.existsMemberByIdAndMemberId(groupId, userId)).thenReturn(true);
+    when(groupMapper.findMemberRanks(eq(groupId), any(), any())).thenReturn(List.of(
+        new GroupMemberRankRow(1, 2L, "bravo", null, 5L),
+        new GroupMemberRankRow(1, 3L, "charlie", "https://example.com/charlie.png", 5L),
+        new GroupMemberRankRow(2, 1L, "alpha", "https://example.com/alpha.png", 2L)
+    ));
+
+    GroupRankResponse response = groupRankService.getRank(groupId, userId);
+
+    assertThat(response.groupId()).isEqualTo(groupId);
+    assertThat(response.rank()).hasSize(3);
+    assertThat(response.rank().get(0).rank()).isEqualTo(1);
+    assertThat(response.rank().get(0).userId()).isEqualTo(2L);
+    assertThat(response.rank().get(0).postCount()).isEqualTo(5L);
+    assertThat(response.rank().get(1).rank()).isEqualTo(1);
+    assertThat(response.rank().get(1).userId()).isEqualTo(3L);
+    assertThat(response.rank().get(2).rank()).isEqualTo(2);
+    assertThat(response.rank().get(2).userId()).isEqualTo(1L);
+    assertThat(response.rank().get(2).postCount()).isEqualTo(2L);
+  }
+
+  @Test
+  void getRankThrowsWhenGroupDoesNotExist() {
+    Long groupId = 10L;
+    Long userId = 2L;
+    when(groupMapper.findActiveById(groupId)).thenReturn(null);
+
+    assertThatThrownBy(() -> groupRankService.getRank(groupId, userId))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.GROUP_NOT_FOUND);
+
+    verify(groupMapper, never()).existsMemberByIdAndMemberId(groupId, userId);
+    verify(groupMapper, never()).findMemberRanks(eq(groupId), any(), any());
+  }
+
+  @Test
+  void getRankThrowsWhenUserIsNotGroupMember() {
+    Long groupId = 10L;
+    Long userId = 2L;
+    when(groupMapper.findActiveById(groupId)).thenReturn(Group.builder().groupId(groupId).build());
+    when(groupMapper.existsMemberByIdAndMemberId(groupId, userId)).thenReturn(false);
+
+    assertThatThrownBy(() -> groupRankService.getRank(groupId, userId))
+        .isInstanceOf(BaseException.class)
+        .extracting(exception -> ((BaseException) exception).getErrorCode())
+        .isEqualTo(ErrorCode.FORBIDDEN);
+
+    verify(groupMapper, never()).findMemberRanks(eq(groupId), any(), any());
+  }
+}

--- a/src/test/java/com/jaeychoi/dailyus/group/service/GroupRankServiceTest.java
+++ b/src/test/java/com/jaeychoi/dailyus/group/service/GroupRankServiceTest.java
@@ -46,12 +46,12 @@ class GroupRankServiceTest {
 
     assertThat(response.groupId()).isEqualTo(groupId);
     assertThat(response.rank()).hasSize(3);
-    assertThat(response.rank().get(0).rank()).isEqualTo(1);
+    assertThat(response.rank().get(0).ranking()).isEqualTo(1);
     assertThat(response.rank().get(0).userId()).isEqualTo(2L);
     assertThat(response.rank().get(0).postCount()).isEqualTo(5L);
-    assertThat(response.rank().get(1).rank()).isEqualTo(1);
+    assertThat(response.rank().get(1).ranking()).isEqualTo(1);
     assertThat(response.rank().get(1).userId()).isEqualTo(3L);
-    assertThat(response.rank().get(2).rank()).isEqualTo(2);
+    assertThat(response.rank().get(2).ranking()).isEqualTo(2);
     assertThat(response.rank().get(2).userId()).isEqualTo(1L);
     assertThat(response.rank().get(2).postCount()).isEqualTo(2L);
   }


### PR DESCRIPTION
## ✨ 작업 내용

- 그룹 내 멤버 랭킹 조회 SQL 구현
- `GroupRankService` 구현
- 그룹 랭킹 조회 API 엔드포인트 구현
- 그룹 랭킹 조회 테스트 추가
- `Rank` 예약어 이슈 수정

## 🔗 관련 이슈
- closes #44 

## 📸 스크린샷 / 참고 자료
<!-- 필요한 경우 첨부 -->
